### PR TITLE
Default to DIV and allow any selector order.

### DIFF
--- a/snabbdom.js
+++ b/snabbdom.js
@@ -61,16 +61,26 @@ function init(modules, api) {
     }
     var elm, children = vnode.children, sel = vnode.sel;
     if (isDef(sel)) {
+
       // Parse selector
-      var hashIdx = sel.indexOf('#');
-      var dotIdx = sel.indexOf('.', hashIdx);
-      var hash = hashIdx > 0 ? hashIdx : sel.length;
-      var dot = dotIdx > 0 ? dotIdx : sel.length;
-      var tag = hashIdx !== -1 || dotIdx !== -1 ? sel.slice(0, Math.min(hash, dot)) : sel;
+      var selectors = sel.split(/((\.|#).+)/);
+      var tag = selectors[0] || 'div';
+      selectors = selectors[1] || '';
+
       elm = vnode.elm = isDef(data) && isDef(i = data.ns) ? api.createElementNS(i, tag)
                                                           : api.createElement(tag);
-      if (hash < dot) elm.id = sel.slice(hash + 1, dot);
-      if (dotIdx > 0) elm.className = sel.slice(dot + 1).replace(/\./g, ' ');
+      var hashparts = selectors.split('#');
+      var id,
+        classes = hashparts.shift().split('.').slice(1);
+
+      for (i = 0; i < hashparts.length; i++) {
+        var dotparts = hashparts[i].split('.');
+        id = dotparts.shift() || undefined;
+        classes.push.apply(classes, dotparts);
+      }
+      if (id) elm.id = id;
+      if (classes.length) elm.className = classes.join(' ');
+
       if (is.array(children)) {
         for (i = 0; i < children.length; ++i) {
           api.appendChild(elm, createElm(children[i], insertedVnodeQueue));


### PR DESCRIPTION
When parsing the `sel` property, while preparing a `patch` operation, default the tag name to DIV when none is provided, such as: `h('#myId', 'my undetermined element')`. Currently snabbdom `patch` throws an error if no tag name is provided in the `sel` property on the virtual dom object.

Example error: http://esnextb.in/?gist=34aae6ae833d915496c546bb1b60858f

Also, allow for any order and number of id's and classes. (Of course only one id is allowed on the `id` property.) Currently snabbdom `patch` ignores classes that occur before id's in the `sel` property.

Example ignore classes before id: http://esnextb.in/?gist=7927c373899c61a3451e79a881a8824b

Some explanation of code implementation:

``` javascript
// Parse selector
var selectors = sel.split(/((\.|#).+)/); // split on first id or class symbol
var tag = selectors[0] || 'div'; // first element is tag, default to DIV if empty string
selectors = selectors[1] || ''; // the rest are id's and classes, if anything

// no change here
elm = vnode.elm = isDef(data) && isDef(i = data.ns) ? api.createElementNS(i, tag)
                                                    : api.createElement(tag);

var hashparts = selectors.split('#'); // start with splitting out id components
var id,
  classes = hashparts.shift().split('.').slice(1);
  // first element of hash split has no id components, only classes, if anything
  // shift it off hashparts, and split it, and dump first item (always empty string)

for (i = 0; i < hashparts.length; i++) { // loop over remaining hash components
  var dotparts = hashparts[i].split('.'); // split classes, first item is an id
  id = dotparts.shift() || undefined; // shift id off dot components
  // each subsequent id overwrites the earlier id's
  // so only one id passes through, the last one in the sel string
  classes.push.apply(classes, dotparts);
  // push and flatten dot components onto classes array
}
if (id) elm.id = id;
if (classes.length) elm.className = classes.join(' ');
// classes is array of class names, so join with a space
```

I've also modularized the script and wrote a bunch of tests:
https://github.com/bloodyKnuckles/simple-selector-parse/blob/master/test/index.js
