### PR TITLE
Adding modules on the fly with patch.extend

### DIFF
--- a/snabbdom.js
+++ b/snabbdom.js
@@ -31,13 +31,6 @@ function init(modules, api) {
 
   if (isUndef(api)) api = domApi;
 
-  for (i = 0; i < hooks.length; ++i) {
-    cbs[hooks[i]] = [];
-    for (j = 0; j < modules.length; ++j) {
-      if (modules[j][hooks[i]] !== undefined) cbs[hooks[i]].push(modules[j][hooks[i]]);
-    }
-  }
-
   function emptyNodeAt(elm) {
     return VNode(api.tagName(elm).toLowerCase(), {}, [], undefined, elm);
   }
@@ -224,7 +217,7 @@ function init(modules, api) {
     }
   }
 
-  return function(oldVnode, vnode) {
+  var patch = function(oldVnode, vnode) {
     var i, elm, parent;
     var insertedVnodeQueue = [];
     for (i = 0; i < cbs.pre.length; ++i) cbs.pre[i]();
@@ -253,6 +246,21 @@ function init(modules, api) {
     for (i = 0; i < cbs.post.length; ++i) cbs.post[i]();
     return vnode;
   };
+
+  patch.extend = function (modules) {
+    if (!is.array(modules)) modules = [modules];
+
+    for (i = 0; i < hooks.length; ++i) {
+      if (!cbs[hooks[i]]) cbs[hooks[i]] = [];
+      for (j = 0; j < modules.length; ++j) {
+        if (modules[j][hooks[i]] !== undefined) cbs[hooks[i]].push(modules[j][hooks[i]]);
+      }
+    }
+  };
+
+  patch.extend(modules);
+
+  return patch;
 }
 
 module.exports = {init: init};


### PR DESCRIPTION
Before it was only one way to add modules - only when you init snabbdom.

Now you can add modules on the fly, like this:

`var patch = snabbdom.init([snabbdom_class, snabbdom_attrs]);`
`patch.extend([{`
`create: function () {},`
`update: function () {},`
`}, {`
`create: function () {},`
`update: function () {},`
`}]);`

or

`var patch = snabbdom.init([snabbdom_class, snabbdom_attrs]);`
`patch.extend({`
`create: function () {},`
`update: function () {},`
`});`

It is very important if you want to make standalone bundle, which already includes all default modules, because in this case there is no way to add additional modules, except this `patch.extend` function.
