### PR TITLE
Fix attribute removal in props updates

### DIFF
--- a/modules/props.js
+++ b/modules/props.js
@@ -1,3 +1,10 @@
+var attributeNameExceptions = {
+  acceptCharset: 'accept-charset',
+  className: 'class',
+  htmlFor: 'for',
+  httpEquiv: 'http-equiv'
+};
+
 function updateProps(oldVnode, vnode) {
   var key, cur, old, elm = vnode.elm,
       oldProps = oldVnode.data.props, props = vnode.data.props;
@@ -8,7 +15,7 @@ function updateProps(oldVnode, vnode) {
 
   for (key in oldProps) {
     if (!props[key]) {
-      delete elm[key];
+      elm.removeAttribute(attributeNameExceptions[key] || key.toLowerCase());
     }
   }
   for (key in props) {

--- a/test/core.js
+++ b/test/core.js
@@ -172,12 +172,24 @@ describe('snabbdom', function() {
       elm = patch(vnode1, vnode2).elm;
       assert.equal(elm.src, 'http://localhost/');
     });
-    it('removes an elements props', function() {
-      var vnode1 = h('a', {props: {src: 'http://other/'}});
-      var vnode2 = h('a');
-      patch(vnode0, vnode1);
-      patch(vnode1, vnode2);
-      assert.equal(elm.src, undefined);
+    [
+      {nodeName: 'a', propName: 'href', attrName: 'href', value: 'http://other/'},
+      {nodeName: 'a', propName: 'className', attrName: 'class', value: 'test'},
+      {nodeName: 'button', propName: 'formAction', attrName: 'formaction', value: 'http://somewhere/'},
+      {nodeName: 'label', propName: 'htmlFor', attrName: 'for', value: 'foo'},
+      {nodeName: 'meta', propName: 'httpEquiv', attrName: 'http-equiv', value: 'refresh'},
+      {nodeName: 'form', propName: 'acceptCharset', attrName: 'accept-charset', value: 'UTF-8'}
+    ].forEach(function(testCase) {
+      it('removes an elements props (' + testCase.propName + ')', function() {
+        var props = {};
+        props[testCase.propName] = testCase.value;
+        var vnode1 = h(testCase.nodeName, {props: props});
+        var vnode2 = h(testCase.nodeName);
+        elm = patch(vnode0, vnode1).elm;
+        assert.equal(elm.getAttribute(testCase.attrName), testCase.value);
+        patch(vnode1, vnode2);
+        assert(!elm.hasAttribute(testCase.attrName));
+      });
     });
     describe('updating children with keys', function() {
       function spanNum(n) {

--- a/test/core.js
+++ b/test/core.js
@@ -137,7 +137,7 @@ describe('snabbdom', function() {
       }
     });
   });
-  describe('pathing an element', function() {
+  describe('patching an element', function() {
     it('changes the elements classes', function() {
       var vnode1 = h('i', {class: {i: true, am: true, horse: true}});
       var vnode2 = h('i', {class: {i: true, am: true, horse: false}});


### PR DESCRIPTION
While developing a cyclejs application, I noticed that sometimes spurious `class` attributes would remain after diffing. After digging a bit, it appears that the test for this functionality wasn't working: it was not checking the right element instance for the attribute, so the test was naively succeeding even though the attribute was not removed.

This patch fixes the test and implements working attribute removal. The `removeAttribute` method is now used for this, which requires us to translate JS property names to DOM attribute names ("className" -> "class"). I added a dependency on `html-attributes` for this.

Initially, I tried setting the attribute properties to `null` or `undefined`, because I didn't want to have to translate the prop names to attribute names. Unfortunately, some HTML attributes like "href" are tricky, and assigning `null` to them actually stringifies the value to `'null'`. So it appears that this added complexity is necessary.
