### PR TITLE
Don't treat Object.prototype properties as boolean attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules
 *.swp
 
 test/browserified.js
+browserified.js

--- a/modules/attributes.js
+++ b/modules/attributes.js
@@ -5,7 +5,7 @@ var booleanAttrs = ["allowfullscreen", "async", "autofocus", "autoplay", "checke
                 "required", "reversed", "scoped", "seamless", "selected", "sortable", "spellcheck", "translate",
                 "truespeed", "typemustmatch", "visible"];
 
-var booleanAttrsDict = {};
+var booleanAttrsDict = Object.create(null);
 for(var i=0, len = booleanAttrs.length; i < len; i++) {
   booleanAttrsDict[booleanAttrs[i]] = true;
 }

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -1,0 +1,59 @@
+var assert = require('assert');
+
+var snabbdom = require('../snabbdom');
+var patch = snabbdom.init([
+  require('../modules/attributes'),
+]);
+var h = require('../h');
+
+describe('attributes', function() {
+  var elm, vnode0;
+  beforeEach(function() {
+    elm = document.createElement('div');
+    vnode0 = elm;
+  });
+  it('have their provided values', function() {
+    var vnode1 = h('div', {attrs: {href: '/foo', minlength: 1, value: true}});
+    elm = patch(vnode0, vnode1).elm;
+    assert.strictEqual(elm.getAttribute('href'), '/foo');
+    assert.strictEqual(elm.getAttribute('minlength'), '1');
+    assert.strictEqual(elm.getAttribute('value'), 'true');
+  });
+  it('are not omitted when falsy values are provided', function() {
+    var vnode1 = h('div', {attrs: {href: null, minlength: 0, value: false}});
+    elm = patch(vnode0, vnode1).elm;
+    assert.strictEqual(elm.getAttribute('href'), 'null');
+    assert.strictEqual(elm.getAttribute('minlength'), '0');
+    assert.strictEqual(elm.getAttribute('value'), 'false');
+  });
+  describe('boolean attribute', function() {
+    it('is present if the value is truthy', function() {
+      var vnode1 = h('div', {attrs: {required: true, readonly: 1, noresize: 'truthy'}});
+      elm = patch(vnode0, vnode1).elm;
+      assert.strictEqual(elm.getAttribute('required'), 'true');
+      assert.strictEqual(elm.getAttribute('readonly'), '1');
+      assert.strictEqual(elm.getAttribute('noresize'), 'truthy');
+    });
+    it('is omitted if the value is falsy', function() {
+      var vnode1 = h('div', {attrs: {required: false, readonly: 0, noresize: null}});
+      elm = patch(vnode0, vnode1).elm;
+      assert.strictEqual(elm.getAttribute('required'), null);
+      assert.strictEqual(elm.getAttribute('readonly'), null);
+      assert.strictEqual(elm.getAttribute('noresize'), null);
+    });
+  });
+  describe('Object.prototype property', function() {
+    it('is not considered as a boolean attribute and shouldn\'t be omitted', function() {
+      var vnode1 = h('div', {attrs: {valueOf: true, toString: 1, constructor: 'truthy'}});
+      elm = patch(vnode0, vnode1).elm;
+      assert.strictEqual(elm.getAttribute('valueOf'), 'true');
+      assert.strictEqual(elm.getAttribute('toString'), '1');
+      assert.strictEqual(elm.getAttribute('constructor'), 'truthy');
+      var vnode2 = h('div', {attrs: {valueOf: false, toString: 0, constructor: null}});
+      elm = patch(vnode0, vnode2).elm;
+      assert.strictEqual(elm.getAttribute('valueOf'), 'false');
+      assert.strictEqual(elm.getAttribute('toString'), '0');
+      assert.strictEqual(elm.getAttribute('constructor'), 'null');
+    })
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -4,3 +4,4 @@ require('./dataset');
 require('./eventlisteners');
 require('./attachto');
 require('./thunk');
+require('./attributes');


### PR DESCRIPTION
Currently boolean element attributes have a special behavior: they are omitted if the value for the attribute key passed in an `attrs` object is falsy.

For performance reasons all the boolean attributes are stored in a native object that acts like a Map. However, objects constructed in a literal form have its prototype set to Object.prototype, so property lookup operation `booleanAttrsDict[key]` will also check for all the properties up on the prototype chain, including Object.prototype.
This makes the attributes with the same names as Object.prototype properties and methods (like `constructor`, `valueOf`, `toString`, etc.) behave like boolean attributes.

This change makes the boolean attributes dictionary prototype-less ([explanation](http://www.2ality.com/2013/10/dict-pattern.html)) to prevent false positives in checking whether the attribute is boolean or not.
I also added some basic tests for attributes module and for this issue in particular.

---

The other way to achieve the same result is to use `Object.prototype.hasOwnProperty` on a plain literal object, but I don't know which one has more efficient performance and how to benchmark it.