### PR TITLE
Handle null and boolean arguments in h helper

### DIFF
--- a/h.js
+++ b/h.js
@@ -13,13 +13,13 @@ function addNS(data, children, sel) {
 
 module.exports = function h(sel, b, c) {
   var data = {}, children, text, i;
-  if (c !== undefined) {
+  if (c != null) {
     data = b;
     if (is.array(c)) { children = c; }
-    else if (is.primitive(c)) { text = c; }
-  } else if (b !== undefined) {
+    else if (is.primitive(c)) { text = String(c); }
+  } else if (b != null) {
     if (is.array(b)) { children = b; }
-    else if (is.primitive(b)) { text = b; }
+    else if (is.primitive(b)) { text = String(b); }
     else { data = b; }
   }
   if (is.array(children)) {

--- a/is.js
+++ b/is.js
@@ -1,4 +1,6 @@
 module.exports = {
   array: Array.isArray,
-  primitive: function(s) { return typeof s === 'string' || typeof s === 'number'; },
+  primitive: function(s) {
+      return typeof s === 'string' || typeof s === 'number' || typeof s === 'boolean';
+  },
 };

--- a/test/core.js
+++ b/test/core.js
@@ -54,6 +54,34 @@ describe('snabbdom', function() {
       var vnode = h('a', {}, 'I am a string');
       assert.equal(vnode.text, 'I am a string');
     });
+    it('can create vnode with props and null text content', function() {
+      var vnode = h('a', {}, null);
+      assert.equal(vnode.text, null);
+    });
+    it('can create vnode with props and number text content', function() {
+      var vnode = h('a', {}, 0);
+      assert.equal(vnode.text, '0');
+    });
+    it('can create vnode with props and without text content', function() {
+      var vnode = h('a', {});
+      assert.strictEqual(vnode.text, undefined);
+    });
+    it('can create vnode with null text content', function() {
+      var vnode = h('a', null);
+      assert.equal(vnode.text, null);
+    });
+    it('can create vnode with number text content', function() {
+      var vnode = h('a', 0);
+      assert.equal(vnode.text, '0');
+    });
+    it('can create vnode with boolean text content', function() {
+      var vnode = h('a', false);
+      assert.equal(vnode.text, 'false');
+    });
+    it('can create vnode without text content', function() {
+      var vnode = h('a');
+      assert.equal(vnode.text, null);
+    });
   });
   describe('created element', function() {
     it('has tag', function() {


### PR DESCRIPTION
Right now when you use short form `h('em', person.name)` and person name is `null`, you get `Uncaught TypeError: Cannot read property 'key' of null` in `vnode.js:2`. 
After this PR, `h` helper (called with 2 or 3 arguments) ignores `null` values and converts number and boolean values to strings.
This is to improve robustness of vnode helper and reduce need for null checks in client code.
