### PR TITLE
Make debugging undefined children easier

### DIFF
--- a/h.js
+++ b/h.js
@@ -23,6 +23,10 @@ module.exports = function h(sel, b, c) {
     else { data = b; }
   }
   if (is.array(children)) {
+    children = children.filter(function() {return true}); // Eliminate possible sparse array
+    if(children.filter(function(c) { return !is.primitive(c) && typeof c !== 'object' || c === null}).length) {
+      throw new TypeError("VNode children array must contain Strings, Numbers, or other VNodes.")
+    }
     for (i = 0; i < children.length; ++i) {
       if (is.primitive(children[i])) children[i] = VNode(undefined, undefined, undefined, children[i]);
     }

--- a/test/core.js
+++ b/test/core.js
@@ -54,6 +54,12 @@ describe('snabbdom', function() {
       var vnode = h('a', {}, 'I am a string');
       assert.equal(vnode.text, 'I am a string');
     });
+    it('throws a type error when the child array has an undefined value', function() {
+      assert.throws(function() { h('div', [h('p'), undefined]) }, TypeError);
+    })
+    it('throws a type error when the child array has a null value', function() {
+      assert.throws(function() { h('div', [h('p'), null]) }, TypeError);
+    })
   });
   describe('created element', function() {
     it('has tag', function() {
@@ -250,6 +256,11 @@ describe('snabbdom', function() {
           elm = patch(vnode1, vnode2).elm;
           assert.equal(elm.children.length, 0);
         });
+        it('works on sparse arrays for children', function() {
+          var vnode1 = h('span', [,,,,1].map(spanNum));
+          elm = patch(vnode0, vnode1).elm;
+          assert.equal(elm.children.length, 1);
+        })
       });
       describe('removal of elements', function() {
         it('removes elements from the beginning', function() {


### PR DESCRIPTION
I find this error to be a very common case: `Cannot read property 'data' of undefined` which occurs when a child of a vnode is undefined during the patch process.

You can never use the stack trace to see where it is coming from in your original code where you construct the tree with `h()` functions. This is because the error arises during the patch process, and no part of the execution path refers to where the `h()` function was originally called. I find this hard to debug

To make the stack trace useful for this error, I added a check at the time the `h()` function is called that will throw a type error if any children are undefined. For sparse arrays, I don't have a good type check for those, so instead I filter them into non-sparse arrays.

Example instances that cause this untraceable error, which can be hard to see just by looking:

`h('div', [,h('p', 'Hi'])`

`h('div', ['hello, ', state.greeting] // state.greeting happens to be undefined or null`
