### PR TITLE
Add `Element` type to PathFunction's first arg

### DIFF
--- a/type-definitions/snabbdom.d.ts
+++ b/type-definitions/snabbdom.d.ts
@@ -81,7 +81,7 @@ export interface SnabbdomAPI<T> {
 
 declare module "snabbdom" {
   export interface PatchFunction {
-    (oldVNode: VNode, vnode: VNode): VNode;
+    (oldVNode: VNode | Element, vnode: VNode): VNode;
   }
 
   export function init(modules: Object, api?: SnabbdomAPI<any>): PatchFunction;


### PR DESCRIPTION
Add `Element` type to PathFunction's first arg.
- snabbdom 0.5.3
- typescript 2.0.3

``` javascript
import * as snabbdom from 'snabbdom';

const h = require('snabbdom/h');
const patch = snabbdom.init([
  require('snabbdom/modules/class'),
  require('snabbdom/modules/class'),
  require('snabbdom/modules/props'),
  require('snabbdom/modules/style'),
  require('snabbdom/modules/eventlisteners'),
]);

const vnode = h('div#container.two.classes', {on: {click: () => console.log('click')}}, [
  h('span', {style: {fontWeight: 'bold'}}, 'This is bold'),
  ' and this is just normal text',
  h('a', {props: {href: '/foo'}}, 'I\'ll take you places!')
]);
const container = document.getElementById('container');
patch(container, vnode);
```

Because, when write above code with typescript, bellow error occured.

``` sh
TypeScript error: src/index.ts(25,7): Error TS2345: Argument of type 'HTMLElement' is not assignable to parameter of type 'VNode'.
  Property 'sel' is missing in type 'HTMLElement'.
```

So, I add `Element` type to PathFunction's first arg like bellow.

``` javascript
declare module "snabbdom" {
  export interface PatchFunction {
    (oldVNode: VNode | Element, vnode: VNode): VNode;
  }

  export function init(modules: Object, api?: SnabbdomAPI<any>): PatchFunction;
}
```
