### PR TITLE
Remove unused non-sameVnode checking in patchVnode

### DIFF
--- a/snabbdom.js
+++ b/snabbdom.js
@@ -195,13 +195,6 @@ function init(modules, api) {
     }
     var elm = vnode.elm = oldVnode.elm, oldCh = oldVnode.children, ch = vnode.children;
     if (oldVnode === vnode) return;
-    if (!sameVnode(oldVnode, vnode)) {
-      var parentElm = api.parentNode(oldVnode.elm);
-      elm = createElm(vnode, insertedVnodeQueue);
-      api.insertBefore(parentElm, elm, oldVnode.elm);
-      removeVnodes(parentElm, [oldVnode], 0, 0);
-      return;
-    }
     if (isDef(vnode.data)) {
       for (i = 0; i < cbs.update.length; ++i) cbs.update[i](oldVnode, vnode);
       i = vnode.data.hook;


### PR DESCRIPTION
It seems that every vnode pair passed to `patchVnode` should satisfy the `sameVnode` checking.
