### PR TITLE
Fix bug of updating one child with same key but different sel.

### DIFF
--- a/src/snabbdom.ts
+++ b/src/snabbdom.ts
@@ -188,9 +188,13 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
           newStartVnode = newCh[++newStartIdx];
         } else {
           elmToMove = oldCh[idxInOld];
-          patchVnode(elmToMove, newStartVnode, insertedVnodeQueue);
-          oldCh[idxInOld] = undefined as any;
-          api.insertBefore(parentElm, elmToMove.elm, oldStartVnode.elm as Element);
+          if (elmToMove.sel !== newStartVnode.sel) {
+            api.insertBefore(parentElm, createElm(newStartVnode, insertedVnodeQueue), oldStartVnode.elm as Element);
+          } else {
+            patchVnode(elmToMove, newStartVnode, insertedVnodeQueue);
+            oldCh[idxInOld] = undefined as any;
+            api.insertBefore(parentElm, elmToMove.elm, oldStartVnode.elm as Element);
+          }
           newStartVnode = newCh[++newStartIdx];
         }
       }
@@ -210,13 +214,6 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
     }
     let elm = vnode.elm = oldVnode.elm, oldCh = oldVnode.children, ch = vnode.children;
     if (oldVnode === vnode) return;
-    if (!sameVnode(oldVnode, vnode)) {
-      const parentElm = api.parentNode(oldVnode.elm as Element);
-      elm = createElm(vnode, insertedVnodeQueue);
-      api.insertBefore(parentElm, elm, oldVnode.elm as Element);
-      removeVnodes(parentElm, [oldVnode], 0, 0);
-      return;
-    }
     if (isDef(vnode.data)) {
       for (i = 0; i < cbs.update.length; ++i) cbs.update[i](oldVnode, vnode);
       i = (vnode.data as VNodeData).hook;

--- a/test/core.js
+++ b/test/core.js
@@ -250,6 +250,16 @@ describe('snabbdom', function() {
           elm = patch(vnode1, vnode2).elm;
           assert.equal(elm.children.length, 0);
         });
+        it('update one child with same key but different sel', function() {
+          var vnode1 = h('span', {key: 'span'}, [1, 2, 3].map(spanNum));
+          var vnode2 = h('span', {key: 'span'}, [spanNum(1), h('i', {key: 2}, '2'), spanNum(3)]);
+          elm = patch(vnode0, vnode1).elm;
+          assert.deepEqual(map(inner, elm.children), ['1', '2', '3']);
+          elm = patch(vnode1, vnode2).elm;
+          assert.deepEqual(map(inner, elm.children), ['1', '2', '3']);
+          assert.equal(elm.children.length, 3);
+          assert.equal(elm.children[1].tagName, 'I');
+        });
       });
       describe('removal of elements', function() {
         it('removes elements from the beginning', function() {


### PR DESCRIPTION
I've created a [pull request](https://github.com/snabbdom/snabbdom/pull/184) days before, but found that is not complete. And the [vdom code of vue](https://github.com/vuejs/vue/blob/dev/src/core/vdom/patch.js#L308) should explain this problem.