### PR TITLE
Allow h(sel, data, node) and h(sel, node) shortcut notations

### DIFF
--- a/h.js
+++ b/h.js
@@ -17,9 +17,11 @@ module.exports = function h(sel, b, c) {
     data = b;
     if (is.array(c)) { children = c; }
     else if (is.primitive(c)) { text = c; }
+    else if (c && c.sel) { children = [c]; }
   } else if (b !== undefined) {
     if (is.array(b)) { children = b; }
     else if (is.primitive(b)) { text = b; }
+    else if (b && b.sel) { children = [b]; }
     else { data = b; }
   }
   if (is.array(children)) {

--- a/test/core.js
+++ b/test/core.js
@@ -42,6 +42,16 @@ describe('snabbdom', function() {
       assert.equal(vnode.children[0].sel, 'span#hello');
       assert.equal(vnode.children[1].sel, 'b.world');
     });
+    it('can create vnode with one child vnode', function() {
+      var vnode = h('div', h('span#hello'));
+      assert.equal(vnode.sel, 'div');
+      assert.equal(vnode.children[0].sel, 'span#hello');
+    });
+    it('can create vnode with props and one child vnode', function() {
+      var vnode = h('div', {}, h('span#hello'));
+      assert.equal(vnode.sel, 'div');
+      assert.equal(vnode.children[0].sel, 'span#hello');
+    });
     it('can create vnode with text content', function() {
       var vnode = h('a', ['I am a string']);
       assert.equal(vnode.children[0].text, 'I am a string');


### PR DESCRIPTION
For two reasons:

- Convenience (virtual-dom does it too)
- As it stands, it's very hard (impossible if you account for people's potential custom modules) to type the `h` function correctly as typescript uses structural typing and the data object being lots of optional things (it will typecheck just fine if you specify them, but the compiler is clueless if you don't), an Array or VNode could pass for an empty data object just fine. If we can't encode it, allow it!