### PR TITLE
Allow h(sel, data, node) and h(sel, node) shortcut notations

### DIFF
--- a/src/h.ts
+++ b/src/h.ts
@@ -22,9 +22,11 @@ export function h(sel: any, b?: any, c?: any): VNode {
     data = b;
     if (is.array(c)) { children = c; }
     else if (is.primitive(c)) { text = c; }
+    else if (c && c.sel) { children = [c]; }
   } else if (b !== undefined) {
     if (is.array(b)) { children = b; }
     else if (is.primitive(b)) { text = b; }
+    else if (b && b.sel) { children = [b]; }
     else { data = b; }
   }
   if (is.array(children)) {

--- a/test/core.js
+++ b/test/core.js
@@ -42,6 +42,16 @@ describe('snabbdom', function() {
       assert.equal(vnode.children[0].sel, 'span#hello');
       assert.equal(vnode.children[1].sel, 'b.world');
     });
+    it('can create vnode with one child vnode', function() {
+      var vnode = h('div', h('span#hello'));
+      assert.equal(vnode.sel, 'div');
+      assert.equal(vnode.children[0].sel, 'span#hello');
+    });
+    it('can create vnode with props and one child vnode', function() {
+      var vnode = h('div', {}, h('span#hello'));
+      assert.equal(vnode.sel, 'div');
+      assert.equal(vnode.children[0].sel, 'span#hello');
+    });
     it('can create vnode with text content', function() {
       var vnode = h('a', ['I am a string']);
       assert.equal(vnode.children[0].text, 'I am a string');


### PR DESCRIPTION
Figured it was easier to create a new branch/PR now that the codebase is rewritten in TS.

Text from the previous PR:

---------------

For two reasons:

- Convenience (virtual-dom does it too)
- As it stands, it's very hard (impossible if you account for people's potential custom modules) to type the `h` function correctly as typescript uses structural typing and the data object being lots of optional things (it will typecheck just fine if you specify them, but the compiler is clueless if you don't), an Array or VNode could pass for an empty data object just fine. If we can't encode it, allow it!


That kind of typing is actually ambiguous. I use overloads myself:  https://github.com/AlexGalays/kaiju/blob/master/src/main.d.ts#L283

If someone tries to write (as of today, by mistake. It happened to a coworker of mine as he used virtual-dom before)

`h('div', someVnode)` then the following overload will be selected:

`function h(selector: string, data: VNodeData)`

It works because data is very polymorphic. You might have props, and/or attrs, some custom module, or nothing at all (everything is optional). Thus, a `VNode` is also a valid `VNodeData` or empty object.

it will compile but you will not see the child.

You could type VNodeData like this: "an object that has at least one of the following key defined : props, attrs, on, etc" but that only works if we don't account for people's custom modules.

---------

Happy to provide more info if required to get this merged
