### PR TITLE
Tweak types, reduce casting

### DIFF
--- a/src/helpers/attachto.ts
+++ b/src/helpers/attachto.ts
@@ -1,7 +1,7 @@
 import {VNode, VNodeData} from '../vnode';
 
 function pre(vnode: VNode, newVnode: VNode): void {
-  var attachData = (vnode.data as VNodeData).attachData;
+  const attachData = (vnode.data as VNodeData).attachData;
   // Copy created placeholder and real element from old vnode
   (newVnode.data as VNodeData).attachData.placeholder = attachData.placeholder;
   (newVnode.data as VNodeData).attachData.real = attachData.real;
@@ -22,8 +22,8 @@ function destroy(vnode: VNode): void {
 }
 
 function create(_: any, vnode: VNode): void {
-  var real = vnode.elm, attachData = (vnode.data as VNodeData).attachData;
-  var placeholder = document.createElement('span');
+  const real = vnode.elm, attachData = (vnode.data as VNodeData).attachData;
+  const placeholder = document.createElement('span');
   // Replace actual element with dummy placeholder
   // Snabbdom will then insert placeholder instead
   vnode.elm = placeholder;
@@ -35,8 +35,8 @@ function create(_: any, vnode: VNode): void {
 export function attachTo(target: Element, vnode: VNode): VNode {
   if (vnode.data === undefined) vnode.data = {};
   if (vnode.data.hook === undefined) vnode.data.hook = {};
-  var data = vnode.data;
-  var hook = vnode.data.hook;
+  const data = vnode.data;
+  const hook = vnode.data.hook;
   data.attachData = {target: target, placeholder: undefined, real: undefined};
   hook.create = create;
   hook.prepatch = pre;

--- a/src/is.ts
+++ b/src/is.ts
@@ -1,4 +1,4 @@
 export const array = Array.isArray;
-export function primitive(s: any): boolean {
+export function primitive(s: any): s is (string | number) {
   return typeof s === 'string' || typeof s === 'number';
-};
+}

--- a/src/snabbdom.ts
+++ b/src/snabbdom.ts
@@ -1,6 +1,6 @@
-/* global require, module, document, Node */
+/* global module, document, Node */
 import {Hooks} from './hooks';
-import vnode, {VNode, VNodeData} from './vnode';
+import vnode, {VNode, VNodeData, Key} from './vnode';
 import * as is from './is';
 import htmlDomApi, {DOMAPI} from './htmldomapi';
 
@@ -15,11 +15,17 @@ function sameVnode(vnode1: VNode, vnode2: VNode): boolean {
   return vnode1.key === vnode2.key && vnode1.sel === vnode2.sel;
 }
 
-function createKeyToOldIdx(children: Array<VNode>, beginIdx: number, endIdx: number): any {
-  let i: number, map: any = {}, key: any;
+function isVnode(vnode: any): vnode is VNode {
+  return vnode.sel !== undefined;
+}
+
+type KeyToIndexMap = {[key: string]: number};
+
+function createKeyToOldIdx(children: Array<VNode>, beginIdx: number, endIdx: number): KeyToIndexMap {
+  let i: number, map: {[s: string]: number} = {}, key: Key;
   for (i = beginIdx; i <= endIdx; ++i) {
     key = children[i].key;
-    if (isDef(key)) map[key] = i;
+    if (key !== undefined) map[key] = i;
   }
   return map;
 }
@@ -31,9 +37,8 @@ export {thunk} from './thunk';
 
 export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
   let i: number, j: number, cbs: any = {};
-  let api: DOMAPI = domApi as DOMAPI;
 
-  if (isUndef(domApi)) api = htmlDomApi;
+  const api: DOMAPI = domApi !== undefined ? domApi : htmlDomApi;
 
   for (i = 0; i < hooks.length; ++i) {
     cbs[hooks[i]] = [];
@@ -48,7 +53,7 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
     return vnode(api.tagName(elm).toLowerCase() + id + c, {}, [], undefined, elm);
   }
 
-  function createRmCb(childElm: Element | Text, listeners: number) {
+  function createRmCb(childElm: Node, listeners: number) {
     return function rmCb() {
       if (--listeners === 0) {
         const parent = api.parentNode(childElm);
@@ -57,32 +62,32 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
     };
   }
 
-  function createElm(vnode: VNode, insertedVnodeQueue: VNodeQueue): Element | Text {
+  function createElm(vnode: VNode, insertedVnodeQueue: VNodeQueue): Node {
     let i: any, data = vnode.data;
-    if (isDef(data)) {
-      if (isDef(i = (data as VNodeData).hook) && isDef(i = i.init)) {
+    if (data !== undefined) {
+      if (isDef(i = data.hook) && isDef(i = i.init)) {
         i(vnode);
         data = vnode.data;
       }
     }
-    let elm: Element | Text, children = vnode.children, sel = vnode.sel;
-    if (isDef(sel)) {
+    let children = vnode.children, sel = vnode.sel;
+    if (sel !== undefined) {
       // Parse selector
-      const hashIdx = (sel as string).indexOf('#');
-      const dotIdx = (sel as string).indexOf('.', hashIdx);
-      const hash = hashIdx > 0 ? hashIdx : (sel as string).length;
-      const dot = dotIdx > 0 ? dotIdx : (sel as string).length;
-      const tag = hashIdx !== -1 || dotIdx !== -1 ? (sel as string).slice(0, Math.min(hash, dot)) : sel;
-      elm = vnode.elm = isDef(data) && isDef(i = (data as VNodeData).ns) ? api.createElementNS(i, tag as string)
-                                                          : api.createElement(tag);
-      if (hash < dot) elm.id = (sel as string).slice(hash + 1, dot);
-      if (dotIdx > 0) elm.className = (sel as string).slice(dot + 1).replace(/\./g, ' ');
+      const hashIdx = sel.indexOf('#');
+      const dotIdx = sel.indexOf('.', hashIdx);
+      const hash = hashIdx > 0 ? hashIdx : sel.length;
+      const dot = dotIdx > 0 ? dotIdx : sel.length;
+      const tag = hashIdx !== -1 || dotIdx !== -1 ? sel.slice(0, Math.min(hash, dot)) : sel;
+      const elm = vnode.elm = isDef(data) && isDef(i = (data as VNodeData).ns) ? api.createElementNS(i, tag)
+                                                                               : api.createElement(tag);
+      if (hash < dot) elm.id = sel.slice(hash + 1, dot);
+      if (dotIdx > 0) elm.className = sel.slice(dot + 1).replace(/\./g, ' ');
       if (is.array(children)) {
         for (i = 0; i < children.length; ++i) {
           api.appendChild(elm, createElm(children[i] as VNode, insertedVnodeQueue));
         }
       } else if (is.primitive(vnode.text)) {
-        api.appendChild(elm, api.createTextNode(vnode.text as string));
+        api.appendChild(elm, api.createTextNode(vnode.text));
       }
       for (i = 0; i < cbs.create.length; ++i) cbs.create[i](emptyNode, vnode);
       i = (vnode.data as VNodeData).hook; // Reuse variable
@@ -91,7 +96,7 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
         if (i.insert) insertedVnodeQueue.push(vnode);
       }
     } else {
-      elm = vnode.elm = api.createTextNode(vnode.text as string);
+      vnode.elm = api.createTextNode(vnode.text as string);
     }
     return vnode.elm;
   }
@@ -109,18 +114,21 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
 
   function invokeDestroyHook(vnode: VNode) {
     let i: any, j: number, data = vnode.data;
-    if (isDef(data)) {
-      if (isDef(i = (data as VNodeData).hook) && isDef(i = i.destroy)) i(vnode);
+    if (data !== undefined) {
+      if (isDef(i = data.hook) && isDef(i = i.destroy)) i(vnode);
       for (i = 0; i < cbs.destroy.length; ++i) cbs.destroy[i](vnode);
-      if (isDef(i = vnode.children)) {
-        for (j = 0; j < (vnode.children as Array<VNode>).length; ++j) {
-          invokeDestroyHook((vnode.children as Array<VNode>)[j]);
+      if (vnode.children !== undefined) {
+        for (j = 0; j < vnode.children.length; ++j) {
+          i = vnode.children[j];
+          if (typeof i !== "string") {
+            invokeDestroyHook(i);
+          }
         }
       }
     }
   }
 
-  function removeVnodes(parentElm: Element,
+  function removeVnodes(parentElm: Node,
                         vnodes: Array<VNode>,
                         startIdx: number,
                         endIdx: number): void {
@@ -130,7 +138,7 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
         if (isDef(ch.sel)) {
           invokeDestroyHook(ch);
           listeners = cbs.remove.length + 1;
-          rm = createRmCb(ch.elm as Element | Text, listeners);
+          rm = createRmCb(ch.elm as Node, listeners);
           for (i = 0; i < cbs.remove.length; ++i) cbs.remove[i](ch, rm);
           if (isDef(i = ch.data) && isDef(i = i.hook) && isDef(i = i.remove)) {
             i(ch, rm);
@@ -138,13 +146,13 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
             rm();
           }
         } else { // Text node
-          api.removeChild(parentElm, ch.elm as Element | Text);
+          api.removeChild(parentElm, ch.elm as Node);
         }
       }
     }
   }
 
-  function updateChildren(parentElm: Element,
+  function updateChildren(parentElm: Node,
                           oldCh: Array<VNode>,
                           newCh: Array<VNode>,
                           insertedVnodeQueue: VNodeQueue) {
@@ -155,7 +163,10 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
     let newEndIdx = newCh.length - 1;
     let newStartVnode = newCh[0];
     let newEndVnode = newCh[newEndIdx];
-    let oldKeyToIdx: any, idxInOld: number, elmToMove: any, before: any;
+    let oldKeyToIdx: any;
+    let idxInOld: number;
+    let elmToMove: VNode;
+    let before: any;
 
     while (oldStartIdx <= oldEndIdx && newStartIdx <= newEndIdx) {
       if (isUndef(oldStartVnode)) {
@@ -172,28 +183,30 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
         newEndVnode = newCh[--newEndIdx];
       } else if (sameVnode(oldStartVnode, newEndVnode)) { // Vnode moved right
         patchVnode(oldStartVnode, newEndVnode, insertedVnodeQueue);
-        api.insertBefore(parentElm, oldStartVnode.elm as Element, api.nextSibling(oldEndVnode.elm as Element));
+        api.insertBefore(parentElm, oldStartVnode.elm as Node, api.nextSibling(oldEndVnode.elm as Node));
         oldStartVnode = oldCh[++oldStartIdx];
         newEndVnode = newCh[--newEndIdx];
       } else if (sameVnode(oldEndVnode, newStartVnode)) { // Vnode moved left
         patchVnode(oldEndVnode, newStartVnode, insertedVnodeQueue);
-        api.insertBefore(parentElm, oldEndVnode.elm as Element, oldStartVnode.elm as Element);
+        api.insertBefore(parentElm, oldEndVnode.elm as Node, oldStartVnode.elm as Node);
         oldEndVnode = oldCh[--oldEndIdx];
         newStartVnode = newCh[++newStartIdx];
       } else {
-        if (isUndef(oldKeyToIdx)) oldKeyToIdx = createKeyToOldIdx(oldCh, oldStartIdx, oldEndIdx);
-        idxInOld = oldKeyToIdx[newStartVnode.key as string | number];
+        if (oldKeyToIdx === undefined) {
+          oldKeyToIdx = createKeyToOldIdx(oldCh, oldStartIdx, oldEndIdx);
+        }
+        idxInOld = oldKeyToIdx[newStartVnode.key as string];
         if (isUndef(idxInOld)) { // New element
-          api.insertBefore(parentElm, createElm(newStartVnode, insertedVnodeQueue), oldStartVnode.elm as Element);
+          api.insertBefore(parentElm, createElm(newStartVnode, insertedVnodeQueue), oldStartVnode.elm as Node);
           newStartVnode = newCh[++newStartIdx];
         } else {
           elmToMove = oldCh[idxInOld];
           if (elmToMove.sel !== newStartVnode.sel) {
-            api.insertBefore(parentElm, createElm(newStartVnode, insertedVnodeQueue), oldStartVnode.elm as Element);
+            api.insertBefore(parentElm, createElm(newStartVnode, insertedVnodeQueue), oldStartVnode.elm as Node);
           } else {
             patchVnode(elmToMove, newStartVnode, insertedVnodeQueue);
             oldCh[idxInOld] = undefined as any;
-            api.insertBefore(parentElm, elmToMove.elm, oldStartVnode.elm as Element);
+            api.insertBefore(parentElm, (elmToMove.elm as Node), oldStartVnode.elm as Node);
           }
           newStartVnode = newCh[++newStartIdx];
         }
@@ -221,17 +234,17 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
     }
     if (isUndef(vnode.text)) {
       if (isDef(oldCh) && isDef(ch)) {
-        if (oldCh !== ch) updateChildren(elm as Element, oldCh as Array<VNode>, ch as Array<VNode>, insertedVnodeQueue);
+        if (oldCh !== ch) updateChildren(elm as Node, oldCh as Array<VNode>, ch as Array<VNode>, insertedVnodeQueue);
       } else if (isDef(ch)) {
-        if (isDef(oldVnode.text)) api.setTextContent(elm as Element, '');
-        addVnodes(elm as Element, null, ch as Array<VNode>, 0, (ch as Array<VNode>).length - 1, insertedVnodeQueue);
+        if (isDef(oldVnode.text)) api.setTextContent(elm as Node, '');
+        addVnodes(elm as Node, null, ch as Array<VNode>, 0, (ch as Array<VNode>).length - 1, insertedVnodeQueue);
       } else if (isDef(oldCh)) {
-        removeVnodes(elm as Element, oldCh as Array<VNode>, 0, (oldCh as Array<VNode>).length - 1);
+        removeVnodes(elm as Node, oldCh as Array<VNode>, 0, (oldCh as Array<VNode>).length - 1);
       } else if (isDef(oldVnode.text)) {
-        api.setTextContent(elm as Element, '');
+        api.setTextContent(elm as Node, '');
       }
     } else if (oldVnode.text !== vnode.text) {
-      api.setTextContent(elm as Element, vnode.text as string);
+      api.setTextContent(elm as Node, vnode.text as string);
     }
     if (isDef(hook) && isDef(i = hook.postpatch)) {
       i(oldVnode, vnode);
@@ -239,25 +252,25 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
   }
 
   return function patch(oldVnode: VNode | Element, vnode: VNode): VNode {
-    let i: number, elm: Element, parent: Element;
+    let i: number, elm: Node, parent: Node;
     const insertedVnodeQueue: VNodeQueue = [];
     for (i = 0; i < cbs.pre.length; ++i) cbs.pre[i]();
 
-    if (isUndef((oldVnode as VNode).sel)) {
-      oldVnode = emptyNodeAt(oldVnode as Element);
+    if (!isVnode(oldVnode)) {
+      oldVnode = emptyNodeAt(oldVnode);
     }
 
-    if (sameVnode(oldVnode as VNode, vnode)) {
-      patchVnode(oldVnode as VNode, vnode, insertedVnodeQueue);
+    if (sameVnode(oldVnode, vnode)) {
+      patchVnode(oldVnode, vnode, insertedVnodeQueue);
     } else {
-      elm = (oldVnode as VNode).elm as Element;
+      elm = oldVnode.elm as Node;
       parent = api.parentNode(elm);
 
       createElm(vnode, insertedVnodeQueue);
 
       if (parent !== null) {
-        api.insertBefore(parent, vnode.elm as Element, api.nextSibling(elm));
-        removeVnodes(parent, [oldVnode as VNode], 0, 0);
+        api.insertBefore(parent, vnode.elm as Node, api.nextSibling(elm));
+        removeVnodes(parent, [oldVnode], 0, 0);
       }
     }
 

--- a/src/vnode.ts
+++ b/src/vnode.ts
@@ -1,12 +1,14 @@
 import {Hooks} from './hooks';
 
+export type Key = string | number | undefined;
+
 export interface VNode {
   sel: string | undefined;
   data: VNodeData | undefined;
   children: Array<VNode | string> | undefined;
-  elm: Element | Text | undefined;
+  elm: Node | undefined;
   text: string | undefined;
-  key: string | number | undefined;
+  key: Key;
 }
 
 export interface VNodeData {


### PR DESCRIPTION
I took a stab at removing some of the casting in the TypeScript port.

Mostly by replacing `isDef(foo)` with `foo !== undefined` because the TS compiler don't understand that `isDef` does `undefined`-checking.

I've removed some other ones by tweaking the types slightly.

I managed to get rid of 19 casts and a few `any`s. 