### PR TITLE
Use `typeof`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gulp-uglify": "^1.5.3",
     "knuth-shuffle": "^1.0.1",
     "testem": "^1.0.2",
-    "typescript": "^2.0.6",
+    "typescript": "^2.1.0",
     "xyz": "0.5.x"
   },
   "scripts": {

--- a/src/h.ts
+++ b/src/h.ts
@@ -1,4 +1,4 @@
-import {vnode, VNode} from './vnode';
+import {vnode, VNode, VNodeData} from './vnode';
 import * as is from './is';
 
 function addNS(data: any, children: Array<VNode> | undefined, sel: string | undefined): void {
@@ -11,13 +11,13 @@ function addNS(data: any, children: Array<VNode> | undefined, sel: string | unde
 }
 
 export function h(sel: string): VNode;
-export function h(sel: string, data: any): VNode;
+export function h(sel: string, data: VNodeData): VNode;
 export function h(sel: string, text: string): VNode;
 export function h(sel: string, children: Array<VNode>): VNode;
-export function h(sel: string, data: any, text: string): VNode;
-export function h(sel: string, data: any, children: Array<VNode>): VNode;
+export function h(sel: string, data: VNodeData, text: string): VNode;
+export function h(sel: string, data: VNodeData, children: Array<VNode>): VNode;
 export function h(sel: any, b?: any, c?: any): VNode {
-  var data = {}, children: any, text: any, i: number;
+  var data: VNodeData = {}, children: any, text: any, i: number;
   if (c !== undefined) {
     data = b;
     if (is.array(c)) { children = c; }

--- a/src/helpers/attachto.ts
+++ b/src/helpers/attachto.ts
@@ -16,7 +16,9 @@ function post(_: any, vnode: VNode): void {
 
 function destroy(vnode: VNode): void {
   // Remove placeholder
-  vnode.elm && vnode.elm.parentElement.removeChild(vnode.elm);
+  if (vnode.elm !== undefined) {
+    (vnode.elm.parentElement as HTMLElement).removeChild(vnode.elm);
+  }
   // Remove real element from where it was inserted
   vnode.elm = (vnode.data as VNodeData).attachData.real;
 }

--- a/src/htmldomapi.ts
+++ b/src/htmldomapi.ts
@@ -35,11 +35,11 @@ function appendChild(node: Node, child: Node): void {
   node.appendChild(child);
 }
 
-function parentNode(node: Node): HTMLElement {
+function parentNode(node: Node): HTMLElement | null {
   return node.parentElement;
 }
 
-function nextSibling(node: Node): Node {
+function nextSibling(node: Node): Node | null {
   return node.nextSibling;
 }
 
@@ -63,4 +63,5 @@ export const htmlDomApi = {
   tagName,
   setTextContent,
 } as DOMAPI;
+
 export default htmlDomApi;

--- a/src/modules/module.d.ts
+++ b/src/modules/module.d.ts
@@ -1,10 +1,10 @@
 import {PreHook, CreateHook, UpdateHook, DestroyHook, RemoveHook, PostHook} from '../hooks';
 
 export interface Module {
-  pre?: PreHook;
-  create?: CreateHook;
-  update?: UpdateHook;
-  destroy?: DestroyHook;
-  remove?: RemoveHook;
-  post?: PostHook;
+  pre: PreHook;
+  create: CreateHook;
+  update: UpdateHook;
+  destroy: DestroyHook;
+  remove: RemoveHook;
+  post: PostHook;
 }

--- a/src/snabbdom.ts
+++ b/src/snabbdom.ts
@@ -225,26 +225,28 @@ export function init(modules: Array<Hooks>, domApi?: DOMAPI) {
     if (isDef(i = vnode.data) && isDef(hook = i.hook) && isDef(i = hook.prepatch)) {
       i(oldVnode, vnode);
     }
-    let elm = vnode.elm = oldVnode.elm, oldCh = oldVnode.children, ch = vnode.children;
+    const elm = vnode.elm = (oldVnode.elm as Node);
+    let oldCh = oldVnode.children;
+    let ch = vnode.children;
     if (oldVnode === vnode) return;
-    if (isDef(vnode.data)) {
+    if (vnode.data !== undefined) {
       for (i = 0; i < cbs.update.length; ++i) cbs.update[i](oldVnode, vnode);
-      i = (vnode.data as VNodeData).hook;
+      i = vnode.data.hook;
       if (isDef(i) && isDef(i = i.update)) i(oldVnode, vnode);
     }
     if (isUndef(vnode.text)) {
       if (isDef(oldCh) && isDef(ch)) {
-        if (oldCh !== ch) updateChildren(elm as Node, oldCh as Array<VNode>, ch as Array<VNode>, insertedVnodeQueue);
+        if (oldCh !== ch) updateChildren(elm, oldCh as Array<VNode>, ch as Array<VNode>, insertedVnodeQueue);
       } else if (isDef(ch)) {
-        if (isDef(oldVnode.text)) api.setTextContent(elm as Node, '');
-        addVnodes(elm as Node, null, ch as Array<VNode>, 0, (ch as Array<VNode>).length - 1, insertedVnodeQueue);
+        if (isDef(oldVnode.text)) api.setTextContent(elm, '');
+        addVnodes(elm, null, ch as Array<VNode>, 0, (ch as Array<VNode>).length - 1, insertedVnodeQueue);
       } else if (isDef(oldCh)) {
-        removeVnodes(elm as Node, oldCh as Array<VNode>, 0, (oldCh as Array<VNode>).length - 1);
+        removeVnodes(elm, oldCh as Array<VNode>, 0, (oldCh as Array<VNode>).length - 1);
       } else if (isDef(oldVnode.text)) {
-        api.setTextContent(elm as Node, '');
+        api.setTextContent(elm, '');
       }
     } else if (oldVnode.text !== vnode.text) {
-      api.setTextContent(elm as Node, vnode.text as string);
+      api.setTextContent(elm, vnode.text as string);
     }
     if (isDef(hook) && isDef(i = hook.postpatch)) {
       i(oldVnode, vnode);

--- a/src/vnode.ts
+++ b/src/vnode.ts
@@ -1,6 +1,6 @@
 import {Hooks} from './hooks';
 
-export type Key = string | number | undefined;
+export type Key = string | number;
 
 export interface VNode {
   sel: string | undefined;
@@ -21,13 +21,13 @@ export interface VNodeData {
   on?: any;
   hero?: any;
   attachData?: any;
-  [key: string]: any; // for any other 3rd party module
-  // end of modules
   hook?: Hooks;
-  key?: string | number;
+  key?: Key;
   ns?: string; // for SVGs
   fn?: () => VNode; // for thunks
   args?: Array<any>; // for thunks
+  [key: string]: any; // for any other 3rd party module
+  // end of modules
 }
 
 export function vnode(sel: string,


### PR DESCRIPTION
This PR uses two nifty new features from TypeScript 2.1. `keyof` and mapped types to typecheck the stored module hooks in `cbs`.

I also changed the type of the `data` argument to `h` from `any` to `VNodeData`. I think that is better as it assures that "known" properties on the data object are type checked.

A few other things are tweaked as well.