### PR TITLE
use parentNode instead of parentElement

### DIFF
--- a/src/helpers/attachto.ts
+++ b/src/helpers/attachto.ts
@@ -16,7 +16,7 @@ function post(_: any, vnode: VNode): void {
 
 function destroy(vnode: VNode): void {
   // Remove placeholder
-  vnode.elm && vnode.elm.parentElement.removeChild(vnode.elm);
+  vnode.elm && vnode.elm.parentNode && vnode.elm.parentNode.removeChild(vnode.elm);
   // Remove real element from where it was inserted
   vnode.elm = (vnode.data as VNodeData).attachData.real;
 }

--- a/src/htmldomapi.ts
+++ b/src/htmldomapi.ts
@@ -5,7 +5,7 @@ export interface DOMAPI {
   insertBefore: (parentNode: Node, newNode: Node, referenceNode: Node | null) => void;
   removeChild: (node: Node, child: Node) => void;
   appendChild: (node: Node, child: Node) => void;
-  parentNode: (node: Node) => HTMLElement;
+  parentNode: (node: Node) => Node;
   nextSibling: (node: Node) => Node;
   tagName: (elm: Element) => string;
   setTextContent: (node: Node, text: string | null) => void;
@@ -35,11 +35,11 @@ function appendChild(node: Node, child: Node): void {
   node.appendChild(child);
 }
 
-function parentNode(node: Node): HTMLElement {
+function parentNode(node: Node): Node | null {
   return node.parentNode;
 }
 
-function nextSibling(node: Node): Node {
+function nextSibling(node: Node): Node | null {
   return node.nextSibling;
 }
 

--- a/src/htmldomapi.ts
+++ b/src/htmldomapi.ts
@@ -36,7 +36,7 @@ function appendChild(node: Node, child: Node): void {
 }
 
 function parentNode(node: Node): HTMLElement {
-  return node.parentElement;
+  return node.parentNode;
 }
 
 function nextSibling(node: Node): Node {

--- a/test/htmldomapi.js
+++ b/test/htmldomapi.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+
+var snabbdom = require('../snabbdom');
+var h = require('../h').default;
+var patch = snabbdom.init([]);
+
+describe('svg', function () {
+ var elm, vnode0;
+ beforeEach(function() {
+   elm = document.createElement('svg');
+   vnode0 = elm;
+ });
+ it('removes svg elements', function(){
+   var a = h('svg', {}, [
+    h('g'),
+    h('g')
+   ]);
+   var b = h('svg', {}, [
+    h('g')
+   ]);
+   var result = patch(patch(vnode0, a), b).elm;
+   assert.equal(result.childNodes.length, 1); 
+ });
+})

--- a/test/htmldomapi.js
+++ b/test/htmldomapi.js
@@ -10,7 +10,7 @@ describe('svg', function () {
    elm = document.createElement('svg');
    vnode0 = elm;
  });
- it('removes svg elements', function(){
+ it('removes child svg elements', function(){
    var a = h('svg', {}, [
     h('g'),
     h('g')

--- a/test/index.js
+++ b/test/index.js
@@ -5,3 +5,4 @@ require('./eventlisteners');
 require('./attachto');
 require('./thunk');
 require('./attributes');
+require('./htmldomapi')


### PR DESCRIPTION
In IE11 children and parentElement are undefined for SVG elements. 
Instead childNodes and parentNode should be used.