### PR TITLE
Speed-up checking boolean attributes

### DIFF
--- a/src/modules/attributes.ts
+++ b/src/modules/attributes.ts
@@ -5,17 +5,21 @@ const NamespaceURIs = {
   "xlink": "http://www.w3.org/1999/xlink"
 };
 
-const booleanAttrs = ["allowfullscreen", "async", "autofocus", "autoplay", "checked", "compact", "controls", "declare",
-                "default", "defaultchecked", "defaultmuted", "defaultselected", "defer", "disabled", "draggable",
-                "enabled", "formnovalidate", "hidden", "indeterminate", "inert", "ismap", "itemscope", "loop", "multiple",
-                "muted", "nohref", "noresize", "noshade", "novalidate", "nowrap", "open", "pauseonexit", "readonly",
-                "required", "reversed", "scoped", "seamless", "selected", "sortable", "spellcheck", "translate",
-                "truespeed", "typemustmatch", "visible"];
+/* Boolean attributes regexp generator (elisp)
+   You can edit list of properties and re-evaluate expression
 
-const booleanAttrsDict = Object.create(null);
-for (let i = 0, len = booleanAttrs.length; i < len; i++) {
-  booleanAttrsDict[booleanAttrs[i]] = true;
-}
+   (replace-regexp "\\(booleanAttrsRegex = \\)[^;]*;"
+   (concat "\\1/^" (replace-regexp-in-string "\\\\" "" (regexp-opt '(
+   "allowfullscreen" "async" "autofocus" "autoplay" "checked" "compact" "controls" "declare"
+   "default" "defaultchecked" "defaultmuted" "defaultselected" "defer" "disabled" "draggable"
+   "enabled" "formnovalidate" "hidden" "indeterminate" "inert" "ismap" "itemscope" "loop" "multiple"
+   "muted" "nohref" "noresize" "noshade" "novalidate" "nowrap" "open" "pauseonexit" "readonly"
+   "required" "reversed" "scoped" "seamless" "selected" "sortable" "spellcheck" "translate"
+   "truespeed" "typemustmatch" "visible"
+   ))) "$/;"))
+*/
+
+export const booleanAttrsRegex = /^(?:a(?:llowfullscreen|sync|uto(?:focus|play))|c(?:hecked|o(?:mpact|ntrols))|d(?:e(?:clare|f(?:ault(?:(?:check|(?:mu|selec)t)ed)?|er))|isabled|raggable)|enabled|formnovalidate|hidden|i(?:n(?:determinate|ert)|smap|temscope)|loop|mu(?:ltiple|ted)|no(?:href|resize|shade|validate|wrap)|open|pauseonexit|re(?:adonly|(?:quir|vers)ed)|s(?:coped|e(?:amless|lected)|ortable|pellcheck)|t(?:r(?:anslate|uespeed)|ypemustmatch)|visible)$/;
 
 function updateAttrs(oldVnode: VNode, vnode: VNode): void {
   var key: string, cur: any, old: any, elm: Element = vnode.elm as Element,
@@ -32,7 +36,7 @@ function updateAttrs(oldVnode: VNode, vnode: VNode): void {
     cur = attrs[key];
     old = oldAttrs[key];
     if (old !== cur) {
-      if (!cur && booleanAttrsDict[key])
+      if (!cur && booleanAttrsRegex.test(key))
         elm.removeAttribute(key);
       else {
         namespaceSplit = key.split(":");


### PR DESCRIPTION
I tried speed-up checking boolean attributes using RegExp instead of lookup key in object.

You can see performance difference for both lookup methods [here](https://gist.github.com/katyo/4c7c469c28b5976e16ca87d89bac382a).

Also I exported Regexp to make it possible use it in other modules (I have one).

*I don't know the generic way to generate regular expression using list of matched words as source. Because I use emacs, so I simply created a script to do that directly in editor.*