### PR TITLE
Create element workflow should align with update element workflow

### DIFF
--- a/src/snabbdom.ts
+++ b/src/snabbdom.ts
@@ -92,6 +92,7 @@ export function init(modules: Array<Partial<Module>>, domApi?: DOMAPI) {
                                                                                : api.createElement(tag);
       if (hash < dot) elm.id = sel.slice(hash + 1, dot);
       if (dotIdx > 0) elm.className = sel.slice(dot + 1).replace(/\./g, ' ');
+      for (i = 0; i < cbs.create.length; ++i) cbs.create[i](emptyNode, vnode);
       if (is.array(children)) {
         for (i = 0; i < children.length; ++i) {
           api.appendChild(elm, createElm(children[i] as VNode, insertedVnodeQueue));
@@ -99,7 +100,6 @@ export function init(modules: Array<Partial<Module>>, domApi?: DOMAPI) {
       } else if (is.primitive(vnode.text)) {
         api.appendChild(elm, api.createTextNode(vnode.text));
       }
-      for (i = 0; i < cbs.create.length; ++i) cbs.create[i](emptyNode, vnode);
       i = (vnode.data as VNodeData).hook; // Reuse variable
       if (isDef(i)) {
         if (i.create) i.create(emptyNode, vnode);


### PR DESCRIPTION
I have noticed that there is a slightly different between the create and update workflows, specifically, during the update process, the element itself is updated first (by calling the update callback), then the children collection is updated, but during the creation, this process is the inverse, and all children are created before the element itself is updated (by calling the create callback).

Considering that for the majority of the modules, the create and update hooks are the same, it makes it difficult to predict if the children collection can still be used in any way. Think of a vnode with a hook to validate, and sanitize the children collection, in which case the process will work only when patching against an existing tree, but not when a new tree is created.

The change itself seems to be trivial, and all tests are still passing. Not sure how to test this in a reliable way.