### PR TITLE
Add reference to "snabby"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ performance, small size and all the features listed below.
   * Server-side HTML output provided by
     [snabbdom-to-html](https://github.com/acstll/snabbdom-to-html).
   * Compact virtual DOM creation with [snabbdom-helpers](https://github.com/krainboltgreene/snabbdom-helpers).
-  * Template string support using [snabby](https://github.com/jamen/snabby)
+  * Template string support using [snabby](https://github.com/jamen/snabby).
 
 ## Inline example
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ performance, small size and all the features listed below.
   * Server-side HTML output provided by
     [snabbdom-to-html](https://github.com/acstll/snabbdom-to-html).
   * Compact virtual DOM creation with [snabbdom-helpers](https://github.com/krainboltgreene/snabbdom-helpers).
+  * Template string support using [snabby](https://github.com/jamen/snabby)
 
 ## Inline example
 


### PR DESCRIPTION
I created a new project today called [snabby](https://github.com/jamen/snabby).  It is experimental, so I apologize if this list is for vetted modules. 

It basically allows you to create virtual nodes using template strings. It also has a `snabby.update` function inspired from how [`yo-yo`](https://npmjs.com/yo-yo) does things.

```js
// Create some vnodes:
var foo = snabby`<div>Hello Earth</div>`
var bar = snabby`<div>Hello Mars</div>`

// Patch to DOM
snabby.update(document.body, foo)

// Patch update
snabby.update(foo, bar)
```

 I was hoping to attract some collaborators, and maybe turn it into something more "official" (whatever that means).  Disclaimer that I'm new to Snabbdom, so this is also a learning process for me.

I was initially inspired because of a framework called [`choo`](https://npmjs.com/choo), which uses `morphdom` (by using `yo-yo`).  I saw benchmarks against the two, and was thinking I could create a module to replace it inside of a fork of `choo`. 

I think some people in https://github.com/substack/hyperx/issues/36 would also be interested.