### PR TITLE
Fix dataset module to support old browsers

### DIFF
--- a/src/modules/dataset.ts
+++ b/src/modules/dataset.ts
@@ -1,8 +1,10 @@
 import {VNode, VNodeData} from '../vnode';
 import {Module} from './module';
 
+const CAPS_REGEX = /[A-Z]/g;
+
 function updateDataset(oldVnode: VNode, vnode: VNode): void {
-  var elm: HTMLElement = vnode.elm as HTMLElement,
+  let elm: HTMLElement = vnode.elm as HTMLElement,
     oldDataset = (oldVnode.data as VNodeData).dataset,
     dataset = (vnode.data as VNodeData).dataset,
     key: string;
@@ -11,15 +13,24 @@ function updateDataset(oldVnode: VNode, vnode: VNode): void {
   if (oldDataset === dataset) return;
   oldDataset = oldDataset || {};
   dataset = dataset || {};
+  const d = elm.dataset;
 
   for (key in oldDataset) {
     if (!dataset[key]) {
-      delete elm.dataset[key];
+      if (d) {
+        delete d[key];
+      } else {
+        elm.removeAttribute('data-' + key.replace(CAPS_REGEX, '-$&').toLowerCase());
+      }
     }
   }
   for (key in dataset) {
     if (oldDataset[key] !== dataset[key]) {
-      elm.dataset[key] = dataset[key];
+      if (d) {
+        d[key] = dataset[key];
+      } else {
+        elm.setAttribute('data-' + key.replace(CAPS_REGEX, '-$&').toLowerCase(), dataset[key]);
+      }
     }
   }
 }


### PR DESCRIPTION
At least IE10 does not support the elm.dataset property, so we must use
elm.removeAttribute and elm.setAttribute instead.

I found this issue when testing Cycle.js against IE10.