### PR TITLE
Fix style module to support old browsers

### DIFF
--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -21,7 +21,7 @@ function updateStyle(oldVnode: VNode, vnode: VNode): void {
 
   for (name in oldStyle) {
     if (!style[name]) {
-      if (name.startsWith('--')) {
+      if (name[0] === '-' && name[1] === '-') {
         (elm as any).style.removeProperty(name);
       } else {
         (elm as any).style[name] = '';
@@ -38,7 +38,7 @@ function updateStyle(oldVnode: VNode, vnode: VNode): void {
         }
       }
     } else if (name !== 'remove' && cur !== oldStyle[name]) {
-      if (name.startsWith('--')) {
+      if (name[0] === '-' && name[1] === '-') {
         (elm as any).style.setProperty(name, cur);
       } else {
         (elm as any).style[name] = cur;


### PR DESCRIPTION
Avoid using String.prototype.startsWith because it is not supported in
browsers like IE10. Also, this commit uses a similar technique already
present in snabbdom (e.g. in the hyperscript implementation, checking
for svg).

Found this issue when testing Cycle.js against IE10.