### PR TITLE
Introduce toVNode() to reconstruct root element as vnode 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ snabbdom.js.map
 thunk.d.ts
 thunk.js
 thunk.js.map
+tovnode.d.ts
+tovnode.js
+tovnode.js.map
 vnode.d.ts
 vnode.js
 vnode.js.map

--- a/src/htmldomapi.ts
+++ b/src/htmldomapi.ts
@@ -10,6 +10,10 @@ export interface DOMAPI {
   nextSibling: (node: Node) => Node;
   tagName: (elm: Element) => string;
   setTextContent: (node: Node, text: string | null) => void;
+  getTextContent: (node: Node) => string | null;
+  isElement: (node: Node) => node is Element;
+  isText: (node: Node) => node is Text;
+  isComment: (node: Node) => node is Comment;
 }
 
 function createElement(tagName: any): HTMLElement {
@@ -56,6 +60,22 @@ function setTextContent(node: Node, text: string | null): void {
   node.textContent = text;
 }
 
+function getTextContent(node: Node): string | null {
+  return node.textContent;
+}
+
+function isElement(node: Node): node is Element {
+  return node.nodeType === 1;
+}
+
+function isText(node: Node): node is Text {
+  return node.nodeType === 3;
+}
+
+function isComment(node: Node): node is Comment {
+  return node.nodeType === 8;
+}
+
 export const htmlDomApi = {
   createElement,
   createElementNS,
@@ -68,6 +88,10 @@ export const htmlDomApi = {
   nextSibling,
   tagName,
   setTextContent,
+  getTextContent,
+  isElement,
+  isText,
+  isComment,
 } as DOMAPI;
 
 export default htmlDomApi;

--- a/src/tovnode.ts
+++ b/src/tovnode.ts
@@ -1,0 +1,39 @@
+import vnode, {VNode} from './vnode';
+import htmlDomApi, {DOMAPI} from './htmldomapi';
+
+export function toVNode(node: Node, domApi?: DOMAPI): VNode {
+  const api: DOMAPI = domApi !== undefined ? domApi : htmlDomApi;
+  let text: string;
+  if (api.isElement(node)) {
+    const id = node.id ? '#' + node.id : '';
+    const cn = node.getAttribute('class');
+    const c = cn ? '.' + cn.split(' ').join('.') : '';
+    const sel = api.tagName(node).toLowerCase() + id + c;
+    const attrs: any = {};
+    const children: Array<VNode> = [];
+    let name: string;
+    let i: number, n: number;
+    const elmAttrs = node.attributes;
+    const elmChildren = node.childNodes;
+    for (i = 0, n = elmAttrs.length; i < n; i++) {
+      name = elmAttrs[i].nodeName;
+      if (name !== 'id' && name !== 'class') {
+        attrs[name] = elmAttrs[i].nodeValue;
+      }
+    }
+    for (i = 0, n = elmChildren.length; i < n; i++) {
+      children.push(toVNode(elmChildren[i]));
+    }
+    return vnode(sel, {attrs}, children, undefined, node);
+  } else if (api.isText(node)) {
+    text = api.getTextContent(node) as string;
+    return vnode(undefined, undefined, undefined, text, undefined);
+  } else if (api.isComment(node)) {
+    text = api.getTextContent(node) as string;
+    return vnode('!', undefined, undefined, text, undefined);
+  } else {
+    return vnode('', {}, [], undefined, undefined);
+  }
+}
+
+export default toVNode;

--- a/src/vnode.ts
+++ b/src/vnode.ts
@@ -30,11 +30,11 @@ export interface VNodeData {
   // end of modules
 }
 
-export function vnode(sel: string,
-               data: any | undefined,
-               children: Array<VNode | string> | undefined,
-               text: string | undefined,
-               elm: Element | Text | undefined): VNode {
+export function vnode(sel: string | undefined,
+                      data: any | undefined,
+                      children: Array<VNode | string> | undefined,
+                      text: string | undefined,
+                      elm: Element | Text | undefined): VNode {
   let key = data === undefined ? undefined : data.key;
   return {sel: sel, data: data, children: children,
           text: text, elm: elm, key: key};

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -44,6 +44,18 @@ describe('attributes', function() {
     elm = patch(vnode0, vnode1).elm;
     assert.strictEqual(elm.getAttributeNS('http://www.w3.org/1999/xlink', 'href'), '#foo');
   });
+  it('should not touch class nor id fields', function() {
+    elm = document.createElement('div');
+    elm.id = 'myId';
+    elm.className = 'myClass';
+    vnode0 = elm;
+    var vnode1 = h('div#myId.myClass', {attrs: {}}, ['Hello']);
+    elm = patch(vnode0, vnode1).elm;
+    assert.strictEqual(elm.tagName, 'DIV');
+    assert.strictEqual(elm.id, 'myId');
+    assert.strictEqual(elm.className, 'myClass');
+    assert.strictEqual(elm.textContent, 'Hello');
+  });
   describe('boolean attribute', function() {
     it('is present if the value is truthy', function() {
       var vnode1 = h('div', {attrs: {required: true, readonly: 1, noresize: 'truthy'}});
@@ -62,16 +74,12 @@ describe('attributes', function() {
   });
   describe('Object.prototype property', function() {
     it('is not considered as a boolean attribute and shouldn\'t be omitted', function() {
-      var vnode1 = h('div', {attrs: {valueOf: true, toString: 1, constructor: 'truthy'}});
+      var vnode1 = h('div', {attrs: {constructor: true}});
       elm = patch(vnode0, vnode1).elm;
-      assert.strictEqual(elm.getAttribute('valueOf'), 'true');
-      assert.strictEqual(elm.getAttribute('toString'), '1');
-      assert.strictEqual(elm.getAttribute('constructor'), 'truthy');
-      var vnode2 = h('div', {attrs: {valueOf: false, toString: 0, constructor: null}});
+      assert.strictEqual(elm.getAttribute('constructor'), 'true');
+      var vnode2 = h('div', {attrs: {constructor: false}});
       elm = patch(vnode0, vnode2).elm;
-      assert.strictEqual(elm.getAttribute('valueOf'), 'false');
-      assert.strictEqual(elm.getAttribute('toString'), '0');
-      assert.strictEqual(elm.getAttribute('constructor'), 'null');
+      assert.strictEqual(elm.getAttribute('constructor'), 'false');
     })
   });
 });

--- a/test/core.js
+++ b/test/core.js
@@ -8,6 +8,7 @@ var patch = snabbdom.init([
   require('../modules/eventlisteners').default,
 ]);
 var h = require('../h').default;
+var toVNode = require('../tovnode').default;
 
 function prop(name) {
   return function(obj) {
@@ -239,6 +240,46 @@ describe('snabbdom', function() {
       patch(vnode0, vnode1);
       patch(vnode1, vnode2);
       assert.equal(elm.src, undefined);
+    });
+    describe('using toVNode()', function () {
+      it('can remove previous children of the root element', function () {
+        var h2 = document.createElement('h2');
+        h2.textContent = 'Hello'
+        var prevElm = document.createElement('div');
+        prevElm.id = 'id';
+        prevElm.className = 'class';
+        prevElm.appendChild(h2);
+        var nextVNode = h('div#id.class', [h('span', 'Hi')]);
+        elm = patch(toVNode(prevElm), nextVNode).elm;
+        assert.strictEqual(elm, prevElm);
+        assert.equal(elm.tagName, 'DIV');
+        assert.equal(elm.id, 'id');
+        assert.equal(elm.className, 'class');
+        assert.strictEqual(elm.childNodes.length, 1);
+        assert.strictEqual(elm.childNodes[0].tagName, 'SPAN');
+        assert.strictEqual(elm.childNodes[0].textContent, 'Hi');
+      });
+      it('can remove some children of the root element', function () {
+        var h2 = document.createElement('h2');
+        h2.textContent = 'Hello'
+        var prevElm = document.createElement('div');
+        prevElm.id = 'id';
+        prevElm.className = 'class';
+        var text = new Text('Foobar');
+        text.testProperty = function () {}; // ensures we dont recreate the Text Node
+        prevElm.appendChild(text);
+        prevElm.appendChild(h2);
+        var nextVNode = h('div#id.class', ['Foobar']);
+        elm = patch(toVNode(prevElm), nextVNode).elm;
+        assert.strictEqual(elm, prevElm);
+        assert.equal(elm.tagName, 'DIV');
+        assert.equal(elm.id, 'id');
+        assert.equal(elm.className, 'class');
+        assert.strictEqual(elm.childNodes.length, 1);
+        assert.strictEqual(elm.childNodes[0].nodeType, 3);
+        assert.strictEqual(elm.childNodes[0].wholeText, 'Foobar');
+        assert.strictEqual(typeof elm.childNodes[0].testProperty, 'function');
+      });
     });
     describe('updating children with keys', function() {
       function spanNum(n) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
         "src/snabbdom.bundle.ts",
         "src/snabbdom.ts",
         "src/thunk.ts",
+        "src/tovnode.ts",
         "src/vnode.ts"
     ]
 }


### PR DESCRIPTION
This commit addresses issue #167. 

Previously, in snabbdom v0.5.0, patch(element, vnode) would always create a new element for the root. This resulted in problems with custom elements (web components), and was fixed in commit c091c59.

However, that commit resulted in bug #167. This meant that snabbdom would have bugs with server-side rendering, where the root element would be non-empty (it has many children, rendered on the server-side as HTML), and the client-side rendering should reuse those existing children (or clear all the children and recreate them again in patch()).

This commit introduces the function toVNode(elm) that deep-converts an element (and its tree) to a VNode (and its tree), that is separately imported and used before calling patch(). toVNode(elm) will look at the element's attributes and gather those as data for the vnode.

Overall, this commit is important for fixing #167 and enabling client/server-side rendering in an efficient manner (destruction/recreation client-side is probably too expensive).

**Would appreciate reviews as soon as possible since this is a critical bug that is blocking development of a new version in Cycle.js** 