### PR TITLE
h() should accept an Array<VNode | string | undefined> as its children

### DIFF
--- a/src/h.ts
+++ b/src/h.ts
@@ -15,10 +15,12 @@ function addNS(data: any, children: Array<VNode> | undefined, sel: string | unde
 
 export function h(sel: string): VNode;
 export function h(sel: string, data: VNodeData): VNode;
+export function h(sel: string, child: VNode): VNode;
 export function h(sel: string, text: string): VNode;
-export function h(sel: string, children: Array<VNode | string>): VNode;
+export function h(sel: string, children: Array<VNode | string | undefined>): VNode;
+export function h(sel: string, data: VNodeData, child: VNode): VNode;
 export function h(sel: string, data: VNodeData, text: string): VNode;
-export function h(sel: string, data: VNodeData, children: Array<VNode | string>): VNode;
+export function h(sel: string, data: VNodeData, children: Array<VNode | string | undefined>): VNode;
 export function h(sel: any, b?: any, c?: any): VNode {
   var data: VNodeData = {}, children: any, text: any, i: number;
   if (c !== undefined) {

--- a/src/h.ts
+++ b/src/h.ts
@@ -16,9 +16,9 @@ function addNS(data: any, children: Array<VNode> | undefined, sel: string | unde
 export function h(sel: string): VNode;
 export function h(sel: string, data: VNodeData): VNode;
 export function h(sel: string, text: string): VNode;
-export function h(sel: string, children: Array<VNode>): VNode;
+export function h(sel: string, children: Array<VNode | string>): VNode;
 export function h(sel: string, data: VNodeData, text: string): VNode;
-export function h(sel: string, data: VNodeData, children: Array<VNode>): VNode;
+export function h(sel: string, data: VNodeData, children: Array<VNode | string>): VNode;
 export function h(sel: any, b?: any, c?: any): VNode {
   var data: VNodeData = {}, children: any, text: any, i: number;
   if (c !== undefined) {


### PR DESCRIPTION
From TypeScript's side, it seems that ```h()``` only accepts an ```Array<VNode>``` as its ```children```.
But its actual implementation can deal with ```string```s and some tests are covering these cases.
Because these tests are written in JavaScript, they cannot detect type mismatch.

For example,
```typescript
h('div', [ 'Hello,', h('br'), 'World!' ])
```
is invalid in TypeScript but can be correctly executed in JavaScript.
This PR fixes the type mismatch so that ```h()``` takes ```children``` as an ```Arrray<VNode | string>```.

By the way, this kind of type mismatch may suggest that tests should also be written in TypeScript...