### PR TITLE
Update `h` signature; children nodes can now be `undefined` or `null`

### DIFF
--- a/src/h.ts
+++ b/src/h.ts
@@ -16,9 +16,9 @@ function addNS(data: any, children: Array<VNode> | undefined, sel: string | unde
 export function h(sel: string): VNode;
 export function h(sel: string, data: VNodeData): VNode;
 export function h(sel: string, text: string): VNode;
-export function h(sel: string, children: Array<VNode>): VNode;
+export function h(sel: string, children: Array<VNode | undefined | null>): VNode;
 export function h(sel: string, data: VNodeData, text: string): VNode;
-export function h(sel: string, data: VNodeData, children: Array<VNode>): VNode;
+export function h(sel: string, data: VNodeData, children: Array<VNode | undefined | null>): VNode;
 export function h(sel: any, b?: any, c?: any): VNode {
   var data: VNodeData = {}, children: any, text: any, i: number;
   if (c !== undefined) {


### PR DESCRIPTION
Required now that #226 is implemented.