### PR TITLE
fix tovnode to ensure text elements can be removed

### DIFF
--- a/src/tovnode.ts
+++ b/src/tovnode.ts
@@ -27,7 +27,7 @@ export function toVNode(node: Node, domApi?: DOMAPI): VNode {
     return vnode(sel, {attrs}, children, undefined, node);
   } else if (api.isText(node)) {
     text = api.getTextContent(node) as string;
-    return vnode(undefined, undefined, undefined, text, undefined);
+    return vnode(undefined, undefined, undefined, text, node);
   } else if (api.isComment(node)) {
     text = api.getTextContent(node) as string;
     return vnode('!', undefined, undefined, text, undefined);

--- a/test/core.js
+++ b/test/core.js
@@ -280,6 +280,25 @@ describe('snabbdom', function() {
         assert.strictEqual(elm.childNodes[0].wholeText, 'Foobar');
         assert.strictEqual(typeof elm.childNodes[0].testProperty, 'function');
       });
+      it('can remove text elements', function () {
+        var h2 = document.createElement('h2');
+        h2.textContent = 'Hello'
+        var prevElm = document.createElement('div');
+        prevElm.id = 'id';
+        prevElm.className = 'class';
+        var text = new Text('Foobar');
+        prevElm.appendChild(text);
+        prevElm.appendChild(h2);
+        var nextVNode = h('div#id.class', [h('h2', 'Hello')]);
+        elm = patch(toVNode(prevElm), nextVNode).elm;
+        assert.strictEqual(elm, prevElm);
+        assert.equal(elm.tagName, 'DIV');
+        assert.equal(elm.id, 'id');
+        assert.equal(elm.className, 'class');
+        assert.strictEqual(elm.childNodes.length, 1);
+        assert.strictEqual(elm.childNodes[0].nodeType, 1);
+        assert.strictEqual(elm.childNodes[0].textContent, 'Hello');
+      })
     });
     describe('updating children with keys', function() {
       function spanNum(n) {


### PR DESCRIPTION
I've added the change to fix https://github.com/snabbdom/snabbdom/issues/252 and added a test that threw the type error before the change and now passes.

This should also fix https://github.com/cyclejs/cyclejs/issues/531