### PR TITLE
use regex to parse selector

### DIFF
--- a/src/snabbdom.ts
+++ b/src/snabbdom.ts
@@ -56,9 +56,8 @@ export function parseSelector(selector: string) {
   const idMatch = selector.match(/#([^.#]+?(?=\.|$))/);
   const id = (idMatch && idMatch[1]) || undefined; // prefer to return `undefined`
   const classNameMatch = selector.match(/\.([^.#]+?(?=[.#]|$))/g);
-  const className = (Array
-    .from(classNameMatch || [])
-    .map(match => match.substring(1).trim())
+  const className = (Array.prototype.slice.call(classNameMatch || [])
+    .map((match: string) => match.substring(1).trim())
     .join(' ')
   ) || undefined;
   return { tag, id, className };

--- a/test/core.js
+++ b/test/core.js
@@ -9,6 +9,7 @@ var patch = snabbdom.init([
 ]);
 var h = require('../h').default;
 var toVNode = require('../tovnode').default;
+var parseSelector = require('../snabbdom').parseSelector;
 
 function prop(name) {
   return function(obj) {
@@ -31,6 +32,62 @@ describe('snabbdom', function() {
   beforeEach(function() {
     elm = document.createElement('div');
     vnode0 = elm;
+  });
+  describe('parseSelector', function () {
+    it('parses tag, id, and classes', function () {
+      var parsedSelector = parseSelector('div#my-id.some.classes.here')
+      assert.equal(parsedSelector.tag, 'div');
+      assert.equal(parsedSelector.id, 'my-id');
+      assert.equal(parsedSelector.className, 'some classes here');
+    });
+    it('parses tag only', function () {
+      var parsedSelector = parseSelector('span')
+      assert.equal(parsedSelector.tag, 'span');
+      assert.equal(parsedSelector.id, undefined);
+      assert.equal(parsedSelector.className, undefined);
+    });
+    it('parses id only', function () {
+      var parsedSelector = parseSelector('#my-id')
+      assert.equal(parsedSelector.tag, undefined);
+      assert.equal(parsedSelector.id, 'my-id');
+      assert.equal(parsedSelector.className, undefined);
+    });
+    it('parses one class only', function () {
+      var parsedSelector = parseSelector('.a-class')
+      assert.equal(parsedSelector.tag, undefined);
+      assert.equal(parsedSelector.id, undefined);
+      assert.equal(parsedSelector.className, 'a-class');
+    });
+    it('parses classes only', function () {
+      var parsedSelector = parseSelector('.a-class.some-other-class.yet-another')
+      assert.equal(parsedSelector.tag, undefined);
+      assert.equal(parsedSelector.id, undefined);
+      assert.equal(parsedSelector.className, 'a-class some-other-class yet-another');
+    });
+    it('parses classes and ids only', function () {
+      var parsedSelector = parseSelector('#myid.some-other-class.yet-another')
+      assert.equal(parsedSelector.tag, undefined);
+      assert.equal(parsedSelector.id, 'myid');
+      assert.equal(parsedSelector.className, 'some-other-class yet-another');
+    });
+    it('parses classes and ids in different orders', function () {
+      var parsedSelector = parseSelector('.some-other-class.yet-another#myid')
+      assert.equal(parsedSelector.tag, undefined);
+      assert.equal(parsedSelector.id, 'myid');
+      assert.equal(parsedSelector.className, 'some-other-class yet-another');
+    });
+    it('parses classes seperated by an id', function () {
+      var parsedSelector = parseSelector('img.a-class#id-in-between.some-other-class')
+      assert.equal(parsedSelector.tag, 'img');
+      assert.equal(parsedSelector.id, 'id-in-between');
+      assert.equal(parsedSelector.className, 'a-class some-other-class');
+    });
+    it('parses with whitespace in between', function () {
+      var parsedSelector = parseSelector('   img   .a-class  #id-in-between.some-other-class  ');
+      assert.equal(parsedSelector.tag, 'img');
+      assert.equal(parsedSelector.id, 'id-in-between');
+      assert.equal(parsedSelector.className, 'a-class some-other-class');
+    });
   });
   describe('hyperscript', function() {
     it('can create vnode with proper tag', function() {


### PR DESCRIPTION
I think this pull is pretty self explanatory. The only issue you might with this is that if the parsed selector couldn't find a tag, then it [defaults to `div`](https://github.com/ricokahler/snabbdom/blob/robust-selector/src/snabbdom.ts#L112). Maybe you'd like to `throw` instead?