### PR TITLE
Fix toVNode() for comment nodes, lacking some fields

### DIFF
--- a/src/tovnode.ts
+++ b/src/tovnode.ts
@@ -30,7 +30,7 @@ export function toVNode(node: Node, domApi?: DOMAPI): VNode {
     return vnode(undefined, undefined, undefined, text, node);
   } else if (api.isComment(node)) {
     text = api.getTextContent(node) as string;
-    return vnode('!', undefined, undefined, text, undefined);
+    return vnode('!', {}, [], text, node as any);
   } else {
     return vnode('', {}, [], undefined, undefined);
   }

--- a/test/style.js
+++ b/test/style.js
@@ -7,6 +7,7 @@ var patch = snabbdom.init([
   require('../modules/style').default,
 ]);
 var h = require('../h').default;
+var toVNode = require('../tovnode').default;
 
 describe('style', function() {
   var elm, vnode0;
@@ -114,6 +115,20 @@ describe('style', function() {
     fakeRaf.step();
     fakeRaf.step();
     assert.equal(elm.style.fontSize, '20px');
+  });
+  describe('using toVNode()', function () {
+    it('handles (ignoring) comment nodes', function() {
+      var comment = document.createComment('yolo');
+      var prevElm = document.createElement('div');
+      prevElm.appendChild(comment);
+      var nextVNode = h('div', [h('span', 'Hi')]);
+      elm = patch(toVNode(prevElm), nextVNode).elm;
+      assert.strictEqual(elm, prevElm);
+      assert.equal(elm.tagName, 'DIV');
+      assert.strictEqual(elm.childNodes.length, 1);
+      assert.strictEqual(elm.childNodes[0].tagName, 'SPAN');
+      assert.strictEqual(elm.childNodes[0].textContent, 'Hi');
+    });
   });
 });
 


### PR DESCRIPTION
Comment nodes when converted to VNode were lacking `vnode.data` and `vnode.elm`, which in turn would break use cases with modules such as the style module (Which assumed `vnode.data` to be truthy). Since `toVNode` is used as an initial step (e.g. for server-side rendered content), there is no reason to not provide `vnode.elm` since that vnode may be used as the "oldvnode" during patch. Also, because comment vnodes have the `'!'` sel, most logic in snabbdom that detects a truthy `sel` will also assume a truthy `data` field. It is easier to build the comment vnode with those fields than to modify all the logic elsewhere in snabbdom. Probably also better for performance.

This fix in snabbdom is important for this issue in Cycle.js: https://github.com/cyclejs/cyclejs/issues/561