### PR TITLE
dont lose listener

### DIFF
--- a/src/modules/eventlisteners.ts
+++ b/src/modules/eventlisteners.ts
@@ -52,6 +52,9 @@ function updateEventListeners(oldVnode: VNode, vnode?: VNode): void {
 
   // optimization for reused immutable handlers
   if (oldOn === on) {
+    if (vnode) {
+      vnode.listener = oldVnode.listener;
+    }
     return;
   }
 

--- a/src/modules/eventlisteners.ts
+++ b/src/modules/eventlisteners.ts
@@ -53,7 +53,7 @@ function updateEventListeners(oldVnode: VNode, vnode?: VNode): void {
   // optimization for reused immutable handlers
   if (oldOn === on) {
     if (vnode) {
-      vnode.listener = oldVnode.listener;
+      (vnode as any).listener = (oldVnode as any).listener;
     }
     return;
   }

--- a/test/eventlisteners.js
+++ b/test/eventlisteners.js
@@ -169,4 +169,18 @@ describe('event listeners', function() {
     elm.firstChild.click();
     assert.equal(3, result.length);
   });
+  it('Rewrite listener on the same node', function() {
+    var result = [];
+    function onClick(ev) {  };
+    function onClick2(ev) { result.push(ev) };
+    var obj = {on: {click: onClick }};
+    var vnode1 = h('div', obj, h('button', {}));
+    patch(vnode0, vnode1);
+    var vnode2 = h('div', obj, h('button', {}, 'Click'));
+    patch(vnode1, vnode2);
+    var vnode3 = h('div', {on: {click: onClick2 }}, h('button', {}, 'Click'));
+    elm = patch(vnode2, vnode3).elm;
+    elm.firstChild.click();
+    assert.equal(1, result.length);
+  });
 });


### PR DESCRIPTION
We have vnode with listener, after that we update vnode, then vnode lose listener.
If vnode lose listener, it will not be able to pass the checking:
`if (oldOn && oldListener) {`