### PR TITLE
PR for issue #262 (remove draggable of boolean attributes)

### DIFF
--- a/src/modules/attributes.ts
+++ b/src/modules/attributes.ts
@@ -2,7 +2,7 @@ import {VNode, VNodeData} from '../vnode';
 import {Module} from './module';
 
 const booleanAttrs = ["allowfullscreen", "async", "autofocus", "autoplay", "checked", "compact", "controls", "declare",
-                "default", "defaultchecked", "defaultmuted", "defaultselected", "defer", "disabled", "draggable",
+                "default", "defaultchecked", "defaultmuted", "defaultselected", "defer", "disabled",
                 "enabled", "formnovalidate", "hidden", "indeterminate", "inert", "ismap", "itemscope", "loop", "multiple",
                 "muted", "nohref", "noresize", "noshade", "novalidate", "nowrap", "open", "pauseonexit", "readonly",
                 "required", "reversed", "scoped", "seamless", "selected", "sortable", "spellcheck", "translate",


### PR DESCRIPTION
Remove draggable from boolean attributes enum.

"This attribute is an enumerated one and not a Boolean one. This means that the explicit usage of one of the values true or false is mandatory and that a shorthand like \<label draggable>Example Label\</label> is not allowed. The correct usage is "\<label draggable="true">Example Label\</label>."