### PR TITLE
fix(dataset): check if property exist before deleting

### DIFF
--- a/src/modules/dataset.ts
+++ b/src/modules/dataset.ts
@@ -19,7 +19,7 @@ function updateDataset(oldVnode: VNode, vnode: VNode): void {
 
   for (key in oldDataset) {
     if (!dataset[key]) {
-      if (d) {
+      if (d && d[key]) {
         delete d[key];
       } else {
         elm.removeAttribute('data-' + key.replace(CAPS_REGEX, '-$&').toLowerCase());

--- a/src/modules/dataset.ts
+++ b/src/modules/dataset.ts
@@ -19,8 +19,10 @@ function updateDataset(oldVnode: VNode, vnode: VNode): void {
 
   for (key in oldDataset) {
     if (!dataset[key]) {
-      if (d && d[key]) {
-        delete d[key];
+      if (d) {
+        if (key in d) {
+          delete d[key];
+        }
       } else {
         elm.removeAttribute('data-' + key.replace(CAPS_REGEX, '-$&').toLowerCase());
       }


### PR DESCRIPTION
in Safari, when it is `use strict`, if the dataset property is removed in DOM
deleting it again will cause an error

closes #309