### PR TITLE
Support DocumentFragment in toVNode()

### DIFF
--- a/src/tovnode.ts
+++ b/src/tovnode.ts
@@ -32,7 +32,7 @@ export function toVNode(node: Node, domApi?: DOMAPI): VNode {
     text = api.getTextContent(node) as string;
     return vnode('!', {}, [], text, node as any);
   } else {
-    return vnode('', {}, [], undefined, undefined);
+    return vnode('', {}, [], undefined, node as any);
   }
 }
 

--- a/test/core.js
+++ b/test/core.js
@@ -9,6 +9,7 @@ var patch = snabbdom.init([
 ]);
 var h = require('../h').default;
 var toVNode = require('../tovnode').default;
+var vnode = require('../vnode').default;
 
 function prop(name) {
   return function(obj) {
@@ -279,6 +280,22 @@ describe('snabbdom', function() {
         assert.strictEqual(elm.childNodes.length, 1);
         assert.strictEqual(elm.childNodes[0].tagName, 'SPAN');
         assert.strictEqual(elm.childNodes[0].textContent, 'Hi');
+      });
+      it('can support patching in a DocumentFragment', function () {
+        var prevElm = document.createDocumentFragment();
+        var nextVNode = vnode('', {}, [
+          h('div#id.class', [h('span', 'Hi')])
+        ], undefined, prevElm);
+        elm = patch(toVNode(prevElm), nextVNode).elm;
+        assert.strictEqual(elm, prevElm);
+        assert.equal(elm.nodeType, 11);
+        assert.equal(elm.childNodes.length, 1);
+        assert.equal(elm.childNodes[0].tagName, 'DIV');
+        assert.equal(elm.childNodes[0].id, 'id');
+        assert.equal(elm.childNodes[0].className, 'class');
+        assert.strictEqual(elm.childNodes[0].childNodes.length, 1);
+        assert.strictEqual(elm.childNodes[0].childNodes[0].tagName, 'SPAN');
+        assert.strictEqual(elm.childNodes[0].childNodes[0].textContent, 'Hi');
       });
       it('can remove some children of the root element', function () {
         var h2 = document.createElement('h2');


### PR DESCRIPTION
This PR is justified on a general level and a specific level.

In general: I believe we don't have a reason to set `vnode.elm` to undefined inside `toVNode()`, no matter what the node is.

In specific: this PR is necessary to support patching inside a DocumentFragment.