### PR TITLE
Fix VNodeStyle

### DIFF
--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -1,9 +1,13 @@
 import {VNode, VNodeData} from '../vnode';
 import {Module} from './module';
 
-export type VNodeStyle = Record<string, string> & {
-  delayed?: Record<string, string>
-  remove?: Record<string, string>
+export type VNodeStyle = {
+  delayed?: { [prop: string]: string };
+  remove?: { [prop: string]: string };
+  destroy?: { [prop: string]: string };
+  [prop: string]: string | {
+    [prop: string]: string
+  } | undefined
 }
 
 var raf = (typeof window !== 'undefined' && window.requestAnimationFrame) || setTimeout;


### PR DESCRIPTION
This allows using `delayed`, `remove`, `destroy` properties, the previous variant gives the typing error.

![image](https://user-images.githubusercontent.com/736697/28637614-99dfc58c-725b-11e7-80ca-2d614bd61d5b.png)
