### PR TITLE
Add package.json/module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ node_modules
 /vnode.js.map
 /modules
 /helpers
+/es

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "A virtual DOM library with focus on simplicity, modularity, powerful features and performance.",
   "main": "snabbdom.js",
+  "module": "es/snabbdom.js",
   "typings": "snabbdom.d.ts",
   "directories": {
     "example": "examples",
@@ -26,7 +27,9 @@
   "scripts": {
     "pretest": "npm run compile",
     "test": "testem",
-    "compile": "tsc",
+    "compile": "npm run compile-es && npm run compile-commonjs",
+    "compile-es": "tsc --outDir es --module es6 --moduleResolution node",
+    "compile-commonjs": "tsc --outDir ./",
     "prepublish": "npm run compile",
     "release-major": "xyz --repo git@github.com:paldepind/snabbdom.git --increment major",
     "release-minor": "xyz --repo git@github.com:paldepind/snabbdom.git --increment minor",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
         "target": "ES5",
-        "outDir": "./",
         "noImplicitAny": true,
         "sourceMap": true,
         "strictNullChecks": true,


### PR DESCRIPTION
Modern module bundlers (e.g webpack 3) can generate a more efficient output when working with ES6 modules.

This PR adds the package.json `module` field, which is not standard (yet?) but is now broadly used by the community. See [here](https://github.com/dherman/defense-of-dot-js/blob/master/proposal.md) for detailed info.

This `module` field points to a new directory where the module syntax is ES6 but everything else is ES5. I usually like to separate the two builds into `commonjs` and `es` folders but this would break backward compatibility when importing modules like `snabbdom/modules/props`. I kept the root file structure for the commonjs version so that existing users using commonjs modules are not impacted.

I didn't touch the README as it's been needing some love for a while and that could be done on the side (it still mentions using require(module).default)