### PR TITLE
Using innerHTML prop to patch non-empty node results in TypeError (null)

### DIFF
--- a/src/snabbdom.ts
+++ b/src/snabbdom.ts
@@ -70,7 +70,9 @@ export function init(modules: Array<Partial<Module>>, domApi?: DOMAPI) {
     return function rmCb() {
       if (--listeners === 0) {
         const parent = api.parentNode(childElm);
-        api.removeChild(parent, childElm);
+        if (parent) {
+          api.removeChild(parent, childElm);
+        }
       }
     };
   }

--- a/test/core.js
+++ b/test/core.js
@@ -336,7 +336,25 @@ describe('snabbdom', function() {
         assert.strictEqual(elm.childNodes.length, 1);
         assert.strictEqual(elm.childNodes[0].nodeType, 1);
         assert.strictEqual(elm.childNodes[0].textContent, 'Hello');
-      })
+      });
+      it('can replace non-empty node with innerHTML prop', function() {
+        var h2 = document.createElement('h2');
+        h2.textContent = 'Hello'
+        var prevElm = document.createElement('div');
+        prevElm.id = 'id';
+        prevElm.className = 'class';
+        prevElm.appendChild(h2);
+        var html = '<span>Hi</span>';
+        var nextVNode = h('div#id.class', { props: { innerHTML: html } });
+        elm = patch(toVNode(prevElm), nextVNode).elm;
+        assert.strictEqual(elm, prevElm);
+        assert.equal(elm.tagName, 'DIV');
+        assert.equal(elm.id, 'id');
+        assert.equal(elm.className, 'class');
+        assert.strictEqual(elm.childNodes.length, 1);
+        assert.strictEqual(elm.childNodes[0].tagName, 'SPAN');
+        assert.strictEqual(elm.childNodes[0].textContent, 'Hi');
+      });
     });
     describe('updating children with keys', function() {
       function spanNum(n) {


### PR DESCRIPTION
I'm using snabbdom through cycle.js.
Recently, I'm stuck on handling server-side-rendered content.
I want to refresh server-side-rendered element with raw html returned from server asynchronously, but it raises a TypeError.

Checking existence of parent can avoid this (see changes), but I couldn't trace why parent is null in this case.

Here is html and js code to reproduce:
```html
<html>
  <head></head>
  <body>
    <div id="container"><h2>Server-side-rendered content</h2></div>
    <script src="./index.js"></script>
  </body>
</html>
```

```js
var snabbdom = require('snabbdom');
var patch = snabbdom.init([
  require('snabbdom/modules/class').default,
  require('snabbdom/modules/props').default,
  require('snabbdom/modules/style').default,
  require('snabbdom/modules/eventlisteners').default,
]);
var h = require('snabbdom/h').default;
var toVNode = require('snabbdom/tovnode').default;
 
var container = document.getElementById('container');
var html= '<h2>asynchronously returned content</h2>';
var vnode = h('div#container', { props: { innerHTML: html } });
patch(toVNode(container), vnode);
```

Here is the error (on Chrome 62.0.3202.94)
<img width="443" alt="2017-12-02 16 28 22" src="https://user-images.githubusercontent.com/3077613/33513010-db29cfec-d77d-11e7-9fdb-cc574cb3c404.png">
