### PR TITLE
fixes issue #348: perf optimization during diffing algo to avoid calling addVNodes and removeVNodes when there is nothing to do

### DIFF
--- a/src/snabbdom.ts
+++ b/src/snabbdom.ts
@@ -240,11 +240,13 @@ export function init(modules: Array<Partial<Module>>, domApi?: DOMAPI) {
         }
       }
     }
-    if (oldStartIdx > oldEndIdx) {
-      before = newCh[newEndIdx+1] == null ? null : newCh[newEndIdx+1].elm;
-      addVnodes(parentElm, before, newCh, newStartIdx, newEndIdx, insertedVnodeQueue);
-    } else if (newStartIdx > newEndIdx) {
-      removeVnodes(parentElm, oldCh, oldStartIdx, oldEndIdx);
+    if (oldStartIdx <= oldEndIdx || newStartIdx <= newEndIdx) {
+      if (oldStartIdx > oldEndIdx) {
+        before = newCh[newEndIdx+1] == null ? null : newCh[newEndIdx+1].elm;
+        addVnodes(parentElm, before, newCh, newStartIdx, newEndIdx, insertedVnodeQueue);
+      } else {
+        removeVnodes(parentElm, oldCh, oldStartIdx, oldEndIdx);
+      }
     }
   }
 


### PR DESCRIPTION
There is a long discussion about this in https://github.com/snabbdom/snabbdom/issues/348. This PR is a resolution of that discussion.