### PR TITLE
 Allow to set delayed or remove keys without typescript error

### DIFF
--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -1,7 +1,7 @@
 import {VNode, VNodeData} from '../vnode';
 import {Module} from './module';
 
-export type VNodeStyle = Record<string, string> & {
+export type VNodeStyle = Record<string, string> | {
   delayed?: Record<string, string>
   remove?: Record<string, string>
 }


### PR DESCRIPTION
Without union when trying to set delayed key, typescript compiler complains like this:
TS2345: Argument of type '{ style: { opacity: string; transition: string; delayed: { opacity: string; }; }; }' is not assignable to parameter of type 'VNodeData'.
  Types of property 'style' are incompatible.
    Type '{ opacity: string; transition: string; delayed: { opacity: string; }; }' is not assignable to type 'VNodeStyle'.
      Type '{ opacity: string; transition: string; delayed: { opacity: string; }; }' is not assignable to type 'Record<string, string>'.
        Property 'delayed' is incompatible with index signature.
          Type '{ opacity: string; }' is not assignable to type 'string'.