### PR TITLE
Allow root DOM with children in patch 

### DIFF
--- a/src/snabbdom.ts
+++ b/src/snabbdom.ts
@@ -62,8 +62,12 @@ export function init(modules: Array<Partial<Module>>, domApi?: DOMAPI) {
 
   function emptyNodeAt(elm: Element) {
     const id = elm.id ? '#' + elm.id : '';
-    const c = elm.className ? '.' + elm.className.split(' ').join('.') : '';
-    return vnode(api.tagName(elm).toLowerCase() + id + c, {}, [], undefined, elm);
+    const c = elm.className && 'string' === typeof elm.ClassName ? '.' + elm.className.split(' ').join('.') : '';
+    const elmvnode = vnode(api.tagName(elm).toLowerCase() + id + c, {}, [], undefined, elm);
+    for (let child: any = elm.firstChild, ii: number = 0; child !== null; child = child.nextSibling, ii++) {
+      if ( 1 === child.nodeType && 'undefined' !== typeof elmvnode.children ) { elmvnode.children[ii] = emptyNodeAt(child) }
+    }
+    return elmvnode
   }
 
   function createRmCb(childElm: Node, listeners: number) {

--- a/test/core.js
+++ b/test/core.js
@@ -264,6 +264,23 @@ describe('snabbdom', function() {
       patch(vnode1, vnode2);
       assert.equal(elm.src, undefined);
     });
+    it('can remove previous children of the root element (w/o toVNode)', function () {
+      var h2 = document.createElement('h2');
+      h2.textContent = 'Hello'
+      var prevElm = document.createElement('div');
+      prevElm.id = 'id';
+      prevElm.className = 'class';
+      prevElm.appendChild(h2);
+      var nextVNode = h('div#id.class', [h('span', 'Hi')]);
+      elm = patch(prevElm, nextVNode).elm;
+      assert.strictEqual(elm, prevElm);
+      assert.equal(elm.tagName, 'DIV');
+      assert.equal(elm.id, 'id');
+      assert.equal(elm.className, 'class');
+      assert.strictEqual(elm.childNodes.length, 1);
+      assert.strictEqual(elm.childNodes[0].tagName, 'SPAN');
+      assert.strictEqual(elm.childNodes[0].textContent, 'Hi');
+    });
     describe('using toVNode()', function () {
       it('can remove previous children of the root element', function () {
         var h2 = document.createElement('h2');


### PR DESCRIPTION
Allow the root DOM element to have children when used as original patch target: `patch(document.getElementById('container'), vtree)`. Without this patch the original child would be ignored and therefore duplicated if included in the `vtree`. This problem can also be overcome with `toVNode` but not always preferable to use it.