### PR TITLE
Refactor to remove function casting.

### DIFF
--- a/src/modules/attributes.ts
+++ b/src/modules/attributes.ts
@@ -1,6 +1,14 @@
 import {VNode, VNodeData} from '../vnode';
 import {Module} from './module';
 
+// because those in TypeScript are too restrictive: https://github.com/Microsoft/TSJS-lib-generator/pull/237
+declare global {
+  interface Element {
+    setAttribute(name: string, value: string | number | boolean): void;
+    setAttributeNS(namespaceURI: string, qualifiedName: string, value: string | number | boolean): void;
+  }
+}
+
 export type Attrs = Record<string, string | number | boolean>
 
 const xlinkNS = 'http://www.w3.org/1999/xlink';
@@ -28,19 +36,16 @@ function updateAttrs(oldVnode: VNode, vnode: VNode): void {
       } else if (cur === false) {
         elm.removeAttribute(key);
       } else {
-        // because those in TypeScript are too restrictive: https://github.com/Microsoft/TSJS-lib-generator/pull/237
-        type SetAttribute = (name: string, value: string | number | boolean) => void;
-        type SetAttributeNS = (namespaceURI: string, qualifiedName: string, value: string | number | boolean) => void;
         if (key.charCodeAt(0) !== xChar) {
-          (elm.setAttribute as SetAttribute)(key, cur);
+          elm.setAttribute(key, cur);
         } else if (key.charCodeAt(3) === colonChar) {
           // Assume xml namespace
-          (elm.setAttributeNS as SetAttributeNS)(xmlNS, key, cur);
+          elm.setAttributeNS(xmlNS, key, cur);
         } else if (key.charCodeAt(5) === colonChar) {
           // Assume xlink namespace
-          (elm.setAttributeNS as SetAttributeNS)(xlinkNS, key, cur);
+          elm.setAttributeNS(xlinkNS, key, cur);
         } else {
-          (elm.setAttribute as SetAttribute)(key, cur);
+          elm.setAttribute(key, cur);
         }
       }
     }


### PR DESCRIPTION
Casting the setAttribute and setAttributeNS functions at each call site make the code harder to read. Instead extract the new overloads for Element into a global declare statement.

This does not change the generated javascript code,  just makes the typescript easier to read.