### PR TITLE
Mention Backbone.VDOMView in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,7 @@ Here are some approaches to building applications with Snabbdom.
   A JavaScript library for rendering html. Tung helps to divide html and JavaScript development.
 * [sprotty](https://github.com/theia-ide/sprotty) - "A web-based diagramming framework" uses Snabbdom.
 * [Mark Text](https://github.com/marktext/marktext) - "Realtime preview Markdown Editor" build on Snabbdom.
+* [Backbone.VDOMView](https://github.com/jcbrand/backbone.vdomview) - A [Backbone](http://backbonejs.org/) View with VirtualDOM capability via Snabbdom.
 
 Be sure to share it if you're building an application in another way
 using Snabbdom.


### PR DESCRIPTION
Hi guys

I created Backbone.VDOMView last year and forgot to mention it here.

Backbone.VDOMView provides a VirtualDOM-aware View for Backbone.js, and its being used by the [Converse.js](https://opkode.com/blog/backbone-vdomview/) XMPP webchat client.

If anyone's interested, I also wrote a blog post about it:
https://opkode.com/blog/backbone-vdomview/