### PR TITLE
Remove redundant is.array check in h

### DIFF
--- a/src/h.ts
+++ b/src/h.ts
@@ -34,7 +34,7 @@ export function h(sel: any, b?: any, c?: any): VNode {
     else if (b && b.sel) { children = [b]; }
     else { data = b; }
   }
-  if (is.array(children)) {
+  if (children !== undefined) {
     for (i = 0; i < children.length; ++i) {
       if (is.primitive(children[i])) children[i] = vnode(undefined, undefined, undefined, children[i], undefined);
     }


### PR DESCRIPTION
In h function, the children variable can be assigned four times (lines 28, 30, 32 and 34) always to an array, making the is.array check in line 37 redundant.



