### PR TITLE
Add toJSON to vnodes

### DIFF
--- a/src/vnode.ts
+++ b/src/vnode.ts
@@ -9,6 +9,7 @@ import {Dataset} from './modules/dataset'
 import {Hero} from './modules/hero'
 
 export type Key = string | number;
+export type JsonVNode = Pick<VNode, Exclude<keyof VNode, "elm" | "toJSON">>;
 
 export interface VNode {
   sel: string | undefined;
@@ -17,7 +18,7 @@ export interface VNode {
   elm: Node | undefined;
   text: string | undefined;
   key: Key | undefined;
-  toJSON(): Pick<VNode, Exclude<keyof VNode, "elm" | "toJSON">>;
+  toJSON(): JsonVNode;
 }
 
 export interface VNodeData {
@@ -37,7 +38,7 @@ export interface VNodeData {
   [key: string]: any; // for any other 3rd party module
 }
 
-function toJSON(this: VNode): Pick<VNode, Exclude<keyof VNode, "elm" | "toJSON">> {
+function toJSON(this: VNode): JsonVNode {
   return {
     sel: this.sel,
     data: this.data,

--- a/src/vnode.ts
+++ b/src/vnode.ts
@@ -17,6 +17,7 @@ export interface VNode {
   elm: Node | undefined;
   text: string | undefined;
   key: Key | undefined;
+  toJSON(): any;
 }
 
 export interface VNodeData {

--- a/src/vnode.ts
+++ b/src/vnode.ts
@@ -37,7 +37,7 @@ export interface VNodeData {
   [key: string]: any; // for any other 3rd party module
 }
 
-function toJSON(this: VNode):any {
+function toJSON(this: VNode): Pick<VNode, Exclude<keyof VNode, "elm" | "toJSON">> {
   return {
     sel: this.sel,
     data: this.data,

--- a/src/vnode.ts
+++ b/src/vnode.ts
@@ -36,6 +36,16 @@ export interface VNodeData {
   [key: string]: any; // for any other 3rd party module
 }
 
+function toJSON(this: VNode):any {
+  return {
+    sel: this.sel,
+    data: this.data,
+    children: this.children,
+    text: this.text,
+    key: this.key,
+  };
+}
+
 export function vnode(sel: string | undefined,
                       data: any | undefined,
                       children: Array<VNode | string> | undefined,
@@ -43,7 +53,7 @@ export function vnode(sel: string | undefined,
                       elm: Element | Text | undefined): VNode {
   let key = data === undefined ? undefined : data.key;
   return {sel: sel, data: data, children: children,
-          text: text, elm: elm, key: key};
+          text: text, elm: elm, key: key, toJSON};
 }
 
 export default vnode;

--- a/src/vnode.ts
+++ b/src/vnode.ts
@@ -17,7 +17,7 @@ export interface VNode {
   elm: Node | undefined;
   text: string | undefined;
   key: Key | undefined;
-  toJSON(): any;
+  toJSON(): Pick<VNode, Exclude<keyof VNode, "elm" | "toJSON">>;
 }
 
 export interface VNodeData {


### PR DESCRIPTION
I wanted to be able to send vnodes to the server and needed to convert them to JSON. The elm properties creates circular references that break JSON.stringify. This pr adds the needed method.