### PR TITLE
Move to karma, allow to test on browserstack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+language: node_js
+node_js:
+  - '6.10.1'
+script:
+  - export IP_ADDR=$(ip addr | grep eth -A 4 | grep 'inet ' | awk '{ print $2 }' | sed 's/\/..//')
+  - npm test
+addons:
+  browserstack:
+    username:
+      secure: <TODO>
+    access_key:
+      secure: <TODO>
+env:
+  global:
+    - secure: <TODO>
+    - secure: <TODO>

--- a/browserstack-karma.js
+++ b/browserstack-karma.js
@@ -1,0 +1,95 @@
+module.exports = {
+  // Latest mainstream
+  BS_Chrome_Current: {
+    base: 'BrowserStack',
+    browser: 'chrome',
+    browser_version: 'latest',
+    os: 'Windows',
+    os_version: '10',
+  },
+  BS_Firefox_Current: {
+    base: 'BrowserStack',
+    browser: 'firefox',
+    browser_version: 'latest',
+    os: 'Windows',
+    os_version: '10',
+  },
+  BS_Safari_Current: {
+    base: 'BrowserStack',
+    browser: 'safari',
+    browser_version: 'latest',
+    os: 'OS X',
+    os_version: 'High Sierra',
+  },
+  BS_Android_8: {
+    base: 'BrowserStack',
+    browser: 'Android',
+    device: 'Google Pixel 2',
+    os: 'Android',
+    os_version: '8.0',
+    real_mobile: true,
+  },
+
+  // Older mainstream
+  BS_Chrome_49: {
+    base: 'BrowserStack',
+    browser: 'chrome',
+    browser_version: '49',
+    os: 'Windows',
+    os_version: '10',
+  },
+  BS_Firefox_52: {
+    base: 'BrowserStack',
+    browser: 'firefox',
+    browser_version: '52',
+    os: 'Windows',
+    os_version: '10',
+  },
+  BS_Safari_9: {
+    base: 'BrowserStack',
+    browser: 'safari',
+    browser_version: '9.1',
+    os: 'OS X',
+    os_version: 'El Capitan',
+  },
+
+  // Misc
+  BS_Android_4_4: {
+    base: 'BrowserStack',
+    device_browser: 'ucbrowser',
+    device: 'Google Nexus 5',
+    os: 'Android',
+    os_version: '4.4',
+    real_mobile: true,
+  },
+  BS_iphone_10: {
+    base: 'BrowserStack',
+    browser: 'Mobile Safari',
+    browser_version: null,
+    device: 'iPhone 7',
+    real_mobile: true,
+    os: 'ios',
+    os_version: '10.3',
+  },
+  BS_MS_Edge: {
+    base: 'BrowserStack',
+    browser: 'edge',
+    browser_version: 'latest',
+    os: 'Windows',
+    os_version: '10',
+  },
+  BS_IE_11: {
+    base: 'BrowserStack',
+    browser: 'ie',
+    browser_version: '11.0',
+    os: 'Windows',
+    os_version: '7',
+  },
+  BS_IE_10: {
+    base: 'BrowserStack',
+    browser: 'ie',
+    browser_version: '10.0',
+    os: 'Windows',
+    os_version: '7',
+  },
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,66 @@
+const ci = !!process.env.CI;
+const watch = !!process.env.WATCH;
+const live = !!process.env.LIVE;
+
+const identifier = process.env.BROWSERSTACK_LOCAL_IDENTIFIER;
+const ip = process.env.IP_ADDR;
+
+const browserstack = require('./browserstack-karma.js');
+
+const browsers = ci
+  ? Object.keys(browserstack)
+  : live
+    ? undefined
+    : watch
+      ? ['Chrome']
+      : ['Chrome', 'Firefox'];
+
+module.exports = function(config) {
+  config.set({
+    basePath: '.',
+    frameworks: ['mocha', 'karma-typescript'],
+    // list of files / patterns to load in the browser
+    files: [{pattern: 'src/**/*.ts'}, {pattern: 'test/**/*'}],
+    plugins: [
+      'karma-mocha',
+      'karma-chrome-launcher',
+      'karma-firefox-launcher',
+      'karma-browserstack-launcher',
+      'karma-typescript',
+    ],
+    hostname: ci ? ip : 'localhost',
+    preprocessors: {
+      'src/**/*.ts': ['karma-typescript'],
+      'test/**/*.js': ['karma-typescript'],
+    },
+    browserStack: {
+      name: 'Snabbdom',
+      startTunnel: false,
+      retryLimit: 3,
+      tunnelIdentifier: identifier,
+    },
+    browserNoActivityTimeout: 1000000,
+    customLaunchers: browserstack,
+    karmaTypescriptConfig: {
+      coverageOptions: {
+        exclude: /test\//,
+      },
+      compilerOptions: {
+        allowJs: true,
+        declaration: false
+      },
+      tsconfig: './tsconfig.json',
+      include: {
+        mode: 'merge',
+        values: ['test/**/*'],
+      },
+    },
+    reporters: ['dots', 'karma-typescript', 'BrowserStack'],
+    port: 9876,
+    colors: true,
+    autoWatch: true,
+    browsers: browsers,
+    singleRun: !watch && !live,
+    concurrency: ci ? 1 : Infinity,
+  });
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "example": "examples",
     "test": "test"
   },
-  "dependencies": {},
   "devDependencies": {
     "benchmark": "^2.1.4",
     "browserify": "^14.4.0",
@@ -19,9 +18,15 @@
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^2.6.0",
     "gulp-uglify": "^3.0.0",
+    "karma": "^3.0.0",
+    "karma-browserstack-launcher": "^1.3.0",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-firefox-launcher": "^1.1.0",
+    "karma-mocha": "^1.3.0",
+    "karma-typescript": "^3.0.13",
     "knuth-shuffle": "^1.0.1",
-    "testem": "^1.18.1",
-    "typescript": "^2.4.2",
+    "mocha": "^5.2.0",
+    "typescript": "^3.0.3",
     "xyz": "2.1.0"
   },
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,0 @@
-require('./core');
-require('./style');
-require('./dataset');
-require('./eventlisteners');
-require('./attachto');
-require('./thunk');
-require('./attributes');
-require('./htmldomapi')


### PR DESCRIPTION
ISSUES FIXED: #396 
Before this can be merged, @paldepind has to activate travis for this repository. I can't finish the travis config until this is done.
Now this allows for easy porting of the tests to typescript
Also this now generates coverage, so there is the possibility of using codecov.io or similar