### PR TITLE
Fix for patching node with text over node with children

### DIFF
--- a/src/snabbdom.ts
+++ b/src/snabbdom.ts
@@ -276,6 +276,9 @@ export function init(modules: Array<Partial<Module>>, domApi?: DOMAPI) {
         api.setTextContent(elm, '');
       }
     } else if (oldVnode.text !== vnode.text) {
+      if (isDef(oldCh)) {
+        removeVnodes(elm, oldCh as Array<VNode>, 0, (oldCh as Array<VNode>).length - 1);
+      }
       api.setTextContent(elm, vnode.text as string);
     }
     if (isDef(hook) && isDef(i = hook.postpatch)) {

--- a/test/core.js
+++ b/test/core.js
@@ -918,6 +918,21 @@ describe('snabbdom', function() {
         patch(vnode1, vnode2);
         assert.equal(1, result.length);
       });
+      it('calls `destroy` listener when patching text node over node with children', function() {
+        var calls = 0;
+        function cb(vnode) {
+          calls++;
+        }
+        var vnode1 = h('div', [
+          h('div', {hook: {destroy: cb}}, [
+            h('span', 'Child 1'),
+          ]),
+        ]);
+        var vnode2 = h('div', 'Text node')
+        patch(vnode0, vnode1);
+        patch(vnode1, vnode2);
+        assert.equal(calls, 1);
+      });
       it('calls `init` and `prepatch` listeners on root', function() {
           var count = 0;
           function init(vnode) {


### PR DESCRIPTION
When patching a text vnode over a vnode with children, the children vnodes must be removed first (so that their hooks are called). The `api.setTextContent` call will end up removing the children elements from the DOM.