### PR TITLE
Fixed #417

### DIFF
--- a/src/modules/props.ts
+++ b/src/modules/props.ts
@@ -21,7 +21,7 @@ function updateProps(oldVnode: VNode, vnode: VNode): void {
   for (key in props) {
     cur = props[key];
     old = oldProps[key];
-    if (old !== cur && (key !== 'value' || (elm as any)[key] !== cur)) {
+    if (old !== cur || (key === 'value' && (elm as any)[key] !== cur)) {
       (elm as any)[key] = cur;
     }
   }

--- a/test/core.js
+++ b/test/core.js
@@ -264,6 +264,14 @@ describe('snabbdom', function() {
       patch(vnode1, vnode2);
       assert.equal(elm.src, undefined);
     });
+    it('changes an elements value-prop it was changed in the dom', function() {
+      var vnode1 = h('input', {props: {value: 'original'}});
+      patch(vnode0, vnode1);
+      vnode1.elm.value = 'changed';
+      var vnode2 = h('input', {props: {value: 'original'}});
+      elm = patch(vnode1, vnode2).elm;
+      assert.equal(elm.value, 'original');
+    });
     describe('using toVNode()', function () {
       it('can remove previous children of the root element', function () {
         var h2 = document.createElement('h2');


### PR DESCRIPTION
This shows and fixes https://github.com/snabbdom/snabbdom/issues/417#issue-407698836

This shows that the current implementation fails if the DOM is changed directly (for example by user input). Because snabbdom doesn't see any changes in the vdom, it doesn't patches it.
