### PR TITLE
Add test case for shorthand and overriding styles

### DIFF
--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -14,8 +14,9 @@ var reflowForced = false;
 function setNextFrame(obj: any, prop: string, val: any): void {
   nextFrame(function() { obj[prop] = val; });
 }
-
+console.log("style.ts called");
 function updateStyle(oldVnode: VNode, vnode: VNode): void {
+  console.log("updateStyle called");
   var cur: any, name: string, elm = vnode.elm,
       oldStyle = (oldVnode.data as VNodeData).style,
       style = (vnode.data as VNodeData).style;

--- a/src/snabbdom.ts
+++ b/src/snabbdom.ts
@@ -46,6 +46,8 @@ export {h} from './h';
 export {thunk} from './thunk';
 
 export function init(modules: Array<Partial<Module>>, domApi?: DOMAPI) {
+  console.log("init called");
+
   let i: number, j: number, cbs = ({} as ModuleHooks);
 
   const api: DOMAPI = domApi !== undefined ? domApi : htmlDomApi;
@@ -287,6 +289,7 @@ export function init(modules: Array<Partial<Module>>, domApi?: DOMAPI) {
   }
 
   return function patch(oldVnode: VNode | Element, vnode: VNode): VNode {
+    console.log("patch");
     let i: number, elm: Node, parent: Node;
     const insertedVnodeQueue: VNodeQueue = [];
     for (i = 0; i < cbs.pre.length; ++i) cbs.pre[i]();
@@ -296,8 +299,10 @@ export function init(modules: Array<Partial<Module>>, domApi?: DOMAPI) {
     }
 
     if (sameVnode(oldVnode, vnode)) {
+      console.log("sameVnode");
       patchVnode(oldVnode, vnode, insertedVnodeQueue);
     } else {
+      console.log("else sameVnode")
       elm = oldVnode.elm as Node;
       parent = api.parentNode(elm);
 

--- a/test/style.js
+++ b/test/style.js
@@ -44,6 +44,31 @@ describe('style', function() {
     assert.equal(elm.style.fontSize, '10px');
     assert.equal(elm.style.display, 'block');
   });
+  it('updates styles with shorthand', function() {
+    var vnode1 = h('i', {style: {padding: '10px 20px 40px'}});
+
+    elm = patch(vnode0, vnode1).elm;
+    assert.equal(elm.style.paddingTop, '10px');
+    assert.equal(elm.style.paddingLeft, '20px');
+    assert.equal(elm.style.paddingRight, '20px');
+    assert.equal(elm.style.paddingBottom, '40px');
+  });
+  it('updates shorthand styles with overriding styles', function() {
+    var vnode1 = h('i', {style: {padding: '10px 20px 40px', paddingRight: '30px'}});
+    var vnode2 = h('i', {style: {padding: '10px 20px 40px'}});
+
+    elm = patch(vnode0, vnode1).elm;
+    assert.equal(elm.style.paddingTop, '10px');
+    assert.equal(elm.style.paddingLeft, '20px');
+    assert.equal(elm.style.paddingRight, '30px');
+    assert.equal(elm.style.paddingBottom, '40px');
+    
+    elm = patch(vnode1, vnode2).elm;
+    assert.equal(elm.style.paddingTop, '10px');
+    assert.equal(elm.style.paddingLeft, '20px');
+    assert.equal(elm.style.paddingRight, '20px');
+    assert.equal(elm.style.paddingBottom, '40px');
+  });
   it('explicialy removes styles', function() {
     var vnode1 = h('i', {style: {fontSize: '14px'}});
     var vnode2 = h('i', {style: {fontSize: ''}});

--- a/test/style.js
+++ b/test/style.js
@@ -53,7 +53,7 @@ describe('style', function() {
     assert.equal(elm.style.paddingRight, '20px');
     assert.equal(elm.style.paddingBottom, '40px');
   });
-  it('updates shorthand styles with overriding styles', function() {
+  it.only('updates shorthand styles with overriding styles', function() {
     var vnode1 = h('i', {style: {padding: '10px 20px 40px', paddingRight: '30px'}});
     var vnode2 = h('i', {style: {padding: '10px 20px 40px'}});
 


### PR DESCRIPTION
Test case to better reproduce #441

**Summary :** 

As per https://developer.mozilla.org/en-US/docs/Web/CSS/padding#Syntax

> When three values are specified, the first padding applies to the top, the second to the left and right, the third to the bottom.
<hr>
Working scenario : ✅<br>
Given ➡  "padding : 10px 20px 40px"<br>
Expected ➡  "paddingTop: 10px, paddingLeft: 20px, paddingRight: 20px, paddingBottom: 40px"<br>
Actual ➡  "paddingTop: 10px, paddingLeft: 20px, paddingRight: 20px, paddingBottom: 40px<br>
<hr>
Failing scenario : ❌<br>
Given ➡  "padding : 10px 20px 40px; paddingRight: 30px"<br>
Expected ➡  "paddingTop: 10px, paddingLeft: 20px, paddingRight: 30px, paddingBottom: 40px"<br>
Actual ➡  "paddingTop: 10px, paddingLeft: 20px, paddingRight: '', paddingBottom: 40px" <br>
<hr>

`paddingRight` is getting cleared

<img width="1680" alt="Screen Shot 2019-08-16 at 12 40 47 AM" src="https://user-images.githubusercontent.com/16179313/63119793-8e15de00-bfbe-11e9-93b4-f3af228ce69f.png">
