### PR TITLE
test: use transitionend instead of settimeout

### DIFF
--- a/test/style.js
+++ b/test/style.js
@@ -118,7 +118,7 @@ describe('style', function() {
   });
   it('applies tranform as transition on remove', function(done) {
     var btn = h('button', { style: {
-        transition: 'transform 0.5s',
+        transition: 'transform 0.1s',
         remove: { transform: 'translateY(100%)' }
     }}, ['A button']);
     var vnode1 = h('div.parent', {}, [btn]);
@@ -126,11 +126,12 @@ describe('style', function() {
     document.body.appendChild(vnode0);
     patch(vnode0, vnode1);
     patch(vnode1, vnode2);
-    assert.strictEqual(document.querySelectorAll('button').length, 1);
-    setTimeout(function () {
-        assert.strictEqual(document.querySelectorAll('button').length, 0);
-        done();
-    }, 700);
+    const button = document.querySelector('button');
+    assert.notStrictEqual(button, null);
+    button.addEventListener('transitionend', function() {
+      assert.strictEqual(document.querySelector('button'), null);
+      done();
+    });
   });
   describe('using toVNode()', function () {
     it('handles (ignoring) comment nodes', function() {


### PR DESCRIPTION
Fixes #447

```
> karma start

05 09 2019 18:35:25.811:INFO [compiler.karma-typescript]: Compiling project using Typescript 3.3.4000
05 09 2019 18:35:31.057:INFO [compiler.karma-typescript]: Compiled 26 files in 5146 ms.
05 09 2019 18:35:32.028:INFO [bundler.karma-typescript]: Bundled imports for 26 file(s) in 469 ms.
05 09 2019 18:35:33.634:INFO [karma-server]: Karma v3.1.4 server started at http://0.0.0.0:9876/
05 09 2019 18:35:33.637:INFO [launcher]: Launching browsers Chrome, Firefox with concurrency unlimited
05 09 2019 18:35:33.655:INFO [launcher]: Starting browser Chrome
05 09 2019 18:35:33.675:INFO [launcher]: Starting browser Firefox
05 09 2019 18:35:36.368:INFO [Chrome 76.0.3809 (Windows 10.0.0)]: Connected on socket Y5ZOZ2SYM9T37QqGAAAA with id 8769878
................................................................................
...................................................................
Chrome 76.0.3809 (Windows 10.0.0): Executed 147 of 147 SUCCESS (0.452 secs / 0.249 secs)
05 09 2019 18:35:40.124:INFO [Firefox 69.0.0 (Windows 10.0.0)]: Connected on socket AcbDDuIsbUD3dl86AAAB with id 5279393
................................................................................
...................................................................
Firefox 69.0.0 (Windows 10.0.0): Executed 147 of 147 SUCCESS (0.586 secs / 0.248 secs)
TOTAL: 294 SUCCESS
```

Mentored by @mightyiam. 