### PR TITLE
Fix element removal on transition end in Firefox70

### DIFF
--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -69,7 +69,7 @@ function applyRemoveStyle(vnode: VNode, rm: () => void): void {
     return;
   }
   if(!reflowForced) {
-    getComputedStyle(document.body).transform;
+    (vnode.elm as any).offsetLeft;
     reflowForced = true;
   }
   var name: string, elm = vnode.elm, i = 0, compStyle: CSSStyleDeclaration,


### PR DESCRIPTION
Apparently Firefox 70 does not reflow the page with `getComputedStyle().transform` any more. Using `element.offsetLeft` apparently works.
Before this fix:
- [Travis log](https://travis-ci.org/cyclejs/cyclejs/builds/603586313#L749)
- [Browserstack](https://automate.browserstack.com/builds/753fb35ae9eafc6785ea775b0796c29c0eb0f9d5) (ignore the failing chrome 49)

After this fix:
[Browserstack session](https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250)

<details><summary>Build log from my local test run</summary><p>

```
Scope: current workspace package

> @cycle/dom@22.4.0 test-browser /home/jan/Dokumente/Programmierprojekte/cyclejs/dom
> karma start

27 10 2019 20:42:06.018:INFO [compiler.karma-typescript]: Compiling project using Typescript 3.2.4
27 10 2019 20:42:09.988:INFO [compiler.karma-typescript]: Compiled 11 files in 3942 ms.
27 10 2019 20:42:11.664:INFO [bundler.karma-typescript]: Bundled imports for 30 file(s) in 1173 ms.
27 10 2019 20:42:12.153:INFO [karma-server]: Karma v4.2.0 server started at http://0.0.0.0:9876/
27 10 2019 20:42:12.154:INFO [launcher]: Launching browsers BS_Chrome_Current, BS_Firefox_Current, BS_Safari_Current, BS_Android_8, BS_Chrome_49, BS_Firefox_52, BS_Safari_9, BS_Android_4_4, BS_iphone_11, BS_MS_Edge, BS_IE_11, BS_IE_10 with concurrency 1
27 10 2019 20:42:12.209:INFO [launcher]: Starting browser chrome latest (Windows 10) on BrowserStack
27 10 2019 20:42:17.701:INFO [launcher.browserstack]: chrome latest (Windows 10) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/6e864865eb891cbed0f42de1d39c2d35dd89686f
27 10 2019 20:42:24.307:INFO [Chrome 78.0.3904 (Windows 10.0.0)]: Connected on socket o2mR2zXc30aAN3uIAAAA with id 95928590
................................................................................
....................
Chrome 78.0.3904 (Windows 10.0.0): Executed 100 of 100 SUCCESS (7.806 secs / 7.294 secs)
27 10 2019 20:42:36.151:INFO [launcher]: Starting browser firefox latest (Windows 10) on BrowserStack
27 10 2019 20:42:38.262:INFO [launcher.browserstack]: firefox latest (Windows 10) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/cd87478ce16ddec2f9465d47bf50c110fda9e667
27 10 2019 20:42:45.470:INFO [Firefox 70.0.0 (Windows 10.0.0)]: Connected on socket hNhxiR5XIa2c3ckYAAAB with id 95940883
....................................................................27 10 2019 20:42:54.622:INFO [Safari 11.1.2 (Mac OS X 10.13.6)]: Connected on socket Jj0TLrvfN90hLHtwAAAC with id 5988172
............
...........................
Safari 11.1.2 (Mac OS X 10.13.6): Executed 39 of 0 SUCCESS (0.441 secs / 3.918 secs)
................................
Firefox 70.0.0 (Windows 10.0.0): Executed 100 of 100 SUCCESS (7.821 secs / 7.378 secs)
27 10 2019 20:42:57.345:INFO [launcher]: Starting browser safari latest (OS X High Sierra) on BrowserStack
................................27 10 2019 20:42:59.329:INFO [launcher.browserstack]: safari latest (OS X High Sierra) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/912024899589902a8eadabb6fb28902156901338
........................................27 10 2019 20:43:04.530:INFO [Safari 11.1.2 (Mac OS X 10.13.6)]: Connected on socket fzsb6luiYzpKikO2AAAD with id 16851665
........
....................
Safari 11.1.2 (Mac OS X 10.13.6): Executed 100 of 100 SUCCESS (8.281 secs / 7.49 secs)
................................................................................
....................
Safari 11.1.2 (Mac OS X 10.13.6): Executed 100 of 100 SUCCESS (8.464 secs / 7.633 secs)
27 10 2019 20:43:17.519:INFO [launcher]: Starting browser Android (Android 8.0) on BrowserStack
27 10 2019 20:43:18.988:INFO [launcher.browserstack]: Android (Android 8.0) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/a7c824004284d688c4bcd07e9a62401aed583856
27 10 2019 20:43:25.243:INFO [Chrome Mobile 76.0.3809 (Android 8.0.0)]: Connected on socket qc7QpQVYEehl773xAAAE with id 52262906
................................................................................
....................
Chrome Mobile 76.0.3809 (Android 8.0.0): Executed 100 of 100 SUCCESS (8.136 secs / 7.534 secs)
27 10 2019 20:43:37.485:INFO [launcher]: Starting browser chrome 49 (Windows 10) on BrowserStack
27 10 2019 20:43:39.913:INFO [launcher.browserstack]: chrome 49 (Windows 10) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/582b5baabf014a82ac3aac44d5eb3bcef38f89fb
27 10 2019 20:43:48.806:INFO [Chrome 49.0.2623 (Windows 10.0.0)]: Connected on socket 5mFpzYSW9YZ1W-rjAAAF with id 4196734
................................................................................
....................
Chrome 49.0.2623 (Windows 10.0.0): Executed 100 of 100 SUCCESS (7.763 secs / 7.291 secs)
27 10 2019 20:44:00.954:INFO [launcher]: Starting browser firefox 52 (Windows 10) on BrowserStack
27 10 2019 20:44:03.369:INFO [launcher.browserstack]: firefox 52 (Windows 10) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/8aaf3e8e75476c52139240c5074c8981b88c1ba6
27 10 2019 20:44:09.469:INFO [Firefox 52.0.0 (Windows 10.0.0)]: Connected on socket lkhXkmlrM-Ldfq8lAAAG with id 57673169
................................................................................
....................
Firefox 52.0.0 (Windows 10.0.0): Executed 100 of 100 SUCCESS (8.368 secs / 7.357 secs)
27 10 2019 20:44:21.928:INFO [launcher]: Starting browser safari 9.1 (OS X El Capitan) on BrowserStack
27 10 2019 20:44:23.148:INFO [launcher.browserstack]: safari 9.1 (OS X El Capitan) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/3f3ed53eefe98f48e0fd2efe83d2acee421037d6
27 10 2019 20:44:32.473:INFO [Safari 9.1.3 (Mac OS X 10.11.6)]: Connected on socket bUDsuYFS-sZoiK-pAAAH with id 13056251
................................................................................
....................
Safari 9.1.3 (Mac OS X 10.11.6): Executed 100 of 100 SUCCESS (8.315 secs / 7.613 secs)
27 10 2019 20:44:44.968:INFO [launcher]: Starting browser Google Nexus 5 (Android 4.4) on BrowserStack
27 10 2019 20:44:45.926:INFO [launcher.browserstack]: Google Nexus 5 (Android 4.4) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/494d8419d4bd026e4cb685975e96fd1085b46241
27 10 2019 20:45:00.119:INFO [Chrome Mobile 76.0.3809 (Android 4.4.0)]: Connected on socket WUD66gW46a--QG3iAAAI with id 84465019
................................................................................
....................
Chrome Mobile 76.0.3809 (Android 4.4.0): Executed 100 of 100 SUCCESS (8.846 secs / 7.913 secs)
27 10 2019 20:45:13.127:INFO [launcher]: Starting browser Mobile Safari (ios 11.0) on BrowserStack
27 10 2019 20:45:14.662:INFO [launcher.browserstack]: Mobile Safari (ios 11.0) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/6cc20d53a1d9289fdeaa4df470331a3a87b39ac3
27 10 2019 20:45:24.792:INFO [Mobile Safari 11.0.0 (iOS 11.0.0)]: Connected on socket TaTL3ZYR1QRruyIbAAAJ with id 64132194
................................................................................
....................
Mobile Safari 11.0.0 (iOS 11.0.0): Executed 100 of 100 SUCCESS (7.987 secs / 7.555 secs)
27 10 2019 20:45:37.090:INFO [launcher]: Starting browser edge latest (Windows 10) on BrowserStack
27 10 2019 20:45:39.634:INFO [launcher.browserstack]: edge latest (Windows 10) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/4cd08121fdbb97bd29bf36954c0dc0ab3b73b499
27 10 2019 20:45:45.720:INFO [Edge 18.18362.0 (Windows 10.0.0)]: Connected on socket oKl-N7nm6XcXc35ZAAAK with id 61551593
................................................................................
....................
Edge 18.18362.0 (Windows 10.0.0): Executed 100 of 100 SUCCESS (7.862 secs / 7.408 secs)
27 10 2019 20:45:58.024:INFO [launcher]: Starting browser ie 11.0 (Windows 7) on BrowserStack
27 10 2019 20:45:59.843:INFO [launcher.browserstack]: ie 11.0 (Windows 7) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/f341401500ecb4a46808fe97f00de92ff56cf4f0
27 10 2019 20:46:32.339:INFO [IE 11.0.0 (Windows 7.0.0)]: Connected on socket PpJUOBtMDJ1_E3cEAAAL with id 92234561
27 10 2019 20:46:33.922:WARN [Safari 11.1.2 (Mac OS X 10.13.6)]: Disconnected (0 times)Client disconnected from CONNECTED state (transport close)
Safari 11.1.2 (Mac OS X 10.13.6) ERROR
  DisconnectedClient disconnected from CONNECTED state (transport close)
................................................................................
....................
IE 11.0.0 (Windows 7.0.0): Executed 100 of 100 SUCCESS (8.622 secs / 7.824 secs)
27 10 2019 20:46:45.262:INFO [launcher]: Starting browser ie 10.0 (Windows 7) on BrowserStack
27 10 2019 20:46:47.541:INFO [launcher.browserstack]: ie 10.0 (Windows 7) session at https://automate.browserstack.com/builds/f587b63c51112ab8dfd1f67370b7849a7962a250/sessions/122dab988800c3172f1600fa078e3759eec3ad54
27 10 2019 20:46:50.970:INFO [IE 10.0.0 (Windows 7.0.0)]: Connected on socket IgMXT3gmeH4HSlaRAAAM with id 20231488
IE 10.0.0 (Windows 7.0.0) ERROR: 'This browser lacks typed array (Uint8Array) support which is required by `buffer` v5.x. Use `buffer` v4.x if you require old browser support.'
IE 10.0.0 (Windows 7.0.0) ERROR: 'This browser lacks typed array (Uint8Array) support which is required by `buffer` v5.x. Use `buffer` v4.x if you require old browser support.'
................................................................................
....................
IE 10.0.0 (Windows 7.0.0): Executed 100 of 100 SUCCESS (8.158 secs / 7.664 secs)
TOTAL: 1300 SUCCESS
```
</p></details>
