### PR TITLE
fix(props): do not attempt to delete node properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,14 @@ Allows you to set properties on DOM elements.
 h('a', {props: {href: '/foo'}}, 'Go to Foo');
 ```
 
+Properties can only be set. Not removed. Even though browsers allow addition and
+deletion of custom properties, deletion will not be attempted by this module.
+This makes sense, because native DOM properties cannot be removed. And
+if you are using custom properties for storing values or referencing
+objects on the DOM, then please consider using
+[data-\* attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes)
+instead. Perhaps via [the dataset module](#the-dataset-module).
+
 ### The attributes module
 
 Same as props, but set attributes instead of properties on DOM elements.

--- a/src/modules/props.ts
+++ b/src/modules/props.ts
@@ -16,11 +16,6 @@ function updateProps (oldVnode: VNode, vnode: VNode): void {
   oldProps = oldProps || {}
   props = props || {}
 
-  for (key in oldProps) {
-    if (!props[key]) {
-      delete (elm as any)[key]
-    }
-  }
   for (key in props) {
     cur = props[key]
     old = oldProps[key]


### PR DESCRIPTION
BREAKING CHANGE: props module does not attempt to delete node
properties. This may affect you if you are using the props module
to add non-native (custom) properties to DOM nodes. Instead, it is
recommended to use _data-* attributes_.
https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes

Fixes #623.
Fixes #283.
Closes #415.
Closes #307.
Closes #151.
Closes #416.