### PR TITLE
Removed duplicate 'h' import in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ performance, small size and all the features listed below.
 ```javascript
 import { init } from 'snabbdom';
 import clazz from 'snabbdom/class';
-import h from 'snabbdom/h';
 import props from 'snabbdom/props';
 import style from 'snabbdom/style';
 import listeners from 'snabbdom/eventlisteners';


### PR DESCRIPTION
It looks like there is two imports with no reasons for this