### PR TITLE
feat(eventlisteners): remove loaded listeners feature

### DIFF
--- a/src/package/modules/eventlisteners.ts
+++ b/src/package/modules/eventlisteners.ts
@@ -12,22 +12,9 @@ function invokeHandler (handler: any, vnode?: VNode, event?: Event): void {
     // call function handler
     handler.call(vnode, event, vnode)
   } else if (typeof handler === 'object') {
-    // call handler with arguments
-    if (typeof handler[0] === 'function') {
-      // special case for single argument for performance
-      if (handler.length === 2) {
-        handler[0].call(vnode, handler[1], event, vnode)
-      } else {
-        var args = handler.slice(1)
-        args.push(event)
-        args.push(vnode)
-        handler[0].apply(vnode, args)
-      }
-    } else {
-      // call multiple handlers
-      for (var i = 0; i < handler.length; i++) {
-        invokeHandler(handler[i], vnode, event)
-      }
+    // call multiple handlers
+    for (var i = 0; i < handler.length; i++) {
+      invokeHandler(handler[i], vnode, event)
     }
   }
 }

--- a/src/test/unit/eventlisteners.ts
+++ b/src/test/unit/eventlisteners.ts
@@ -54,62 +54,6 @@ describe('event listeners', function () {
     elm.click()
     assert.deepEqual(result, [1, 2])
   })
-  it('does calls handler for function in array', function () {
-    var result: number[] = []
-    function clicked (n: number) {
-      result.push(n)
-    }
-    var vnode = h('div', { on: { click: [clicked, 1] as any } }, [
-      h('a', 'Click my parent'),
-    ])
-    elm = patch(vnode0, vnode).elm
-    elm.click()
-    assert.deepEqual(result, [1])
-  })
-  it('handles changed value in array', function () {
-    var result: number[] = []
-    function clicked (n: number) {
-      result.push(n)
-    }
-    var vnode1 = h('div', { on: { click: [clicked, 1] as any } }, [
-      h('a', 'Click my parent'),
-    ])
-    var vnode2 = h('div', { on: { click: [clicked, 2] as any } }, [
-      h('a', 'Click my parent'),
-    ])
-    var vnode3 = h('div', { on: { click: [clicked, 3] as any } }, [
-      h('a', 'Click my parent'),
-    ])
-    elm = patch(vnode0, vnode1).elm
-    elm.click()
-    elm = patch(vnode1, vnode2).elm
-    elm.click()
-    elm = patch(vnode2, vnode3).elm
-    elm.click()
-    assert.deepEqual(result, [1, 2, 3])
-  })
-  it('handles changed several values in array', function () {
-    var result: number[][] = []
-    function clicked () {
-      result.push([].slice.call(arguments, 0, arguments.length - 2))
-    }
-    var vnode1 = h('div', { on: { click: [clicked, 1, 2, 3] as any } }, [
-      h('a', 'Click my parent'),
-    ])
-    var vnode2 = h('div', { on: { click: [clicked, 1, 2] as any } }, [
-      h('a', 'Click my parent'),
-    ])
-    var vnode3 = h('div', { on: { click: [clicked, 2, 3] as any } }, [
-      h('a', 'Click my parent'),
-    ])
-    elm = patch(vnode0, vnode1).elm
-    elm.click()
-    elm = patch(vnode1, vnode2).elm
-    elm.click()
-    elm = patch(vnode2, vnode3).elm
-    elm.click()
-    assert.deepEqual(result, [[1, 2, 3], [1, 2], [2, 3]])
-  })
   it('detach attached click event handler to element', function () {
     var result: Event[] = []
     function clicked (ev: Event) {
@@ -137,13 +81,13 @@ describe('event listeners', function () {
       // Check that the second argument was a vnode
       assert.strictEqual(vnode.sel, 'div')
     }
-    var vnode1 = h('div', { on: { click: [[clicked], [clicked], [clicked]] as any } }, [
+    var vnode1 = h('div', { on: { click: [clicked, clicked, clicked] as any } }, [
       h('a', 'Click my parent'),
     ])
     elm = patch(vnode0, vnode1).elm
     elm.click()
     assert.strictEqual(3, called)
-    var vnode2 = h('div', { on: { click: [[clicked], [clicked]] as any } }, [
+    var vnode2 = h('div', { on: { click: [clicked, clicked] as any } }, [
       h('a', 'Click my parent'),
     ])
     elm = patch(vnode1, vnode2).elm
@@ -157,36 +101,6 @@ describe('event listeners', function () {
       result.push(vnode)
     }
     var vnode1 = h('div', { on: { click: clicked } as any }, [
-      h('a', 'Click my parent'),
-    ])
-    elm = patch(vnode0, vnode1).elm
-    elm.click()
-    assert.strictEqual(2, result.length)
-    assert.strictEqual(vnode1, result[0])
-    assert.strictEqual(vnode1, result[1])
-  })
-  it('access to virtual node in event handler with argument', function () {
-    var result: VNode[] = []
-    function clicked (this: VNode, arg: number, ev: Event, vnode: VNode) {
-      result.push(this)
-      result.push(vnode)
-    }
-    var vnode1 = h('div', { on: { click: [clicked, 1] as any } }, [
-      h('a', 'Click my parent'),
-    ])
-    elm = patch(vnode0, vnode1).elm
-    elm.click()
-    assert.strictEqual(2, result.length)
-    assert.strictEqual(vnode1, result[0])
-    assert.strictEqual(vnode1, result[1])
-  })
-  it('access to virtual node in event handler with arguments', function () {
-    var result: VNode[] = []
-    function clicked (this: VNode, arg1: number, arg2: string, ev: Event, vnode: VNode) {
-      result.push(this)
-      result.push(vnode)
-    }
-    var vnode1 = h('div', { on: { click: [clicked, 1, '2'] as any } }, [
       h('a', 'Click my parent'),
     ])
     elm = patch(vnode0, vnode1).elm


### PR DESCRIPTION
BREAKING CHANGE: loaded/carrying event listeners are no longer supported.
For alternatives see issue #802.

Fixes #802