### PR TITLE
Fix style.ts for headless environments

### DIFF
--- a/src/package/modules/style.ts
+++ b/src/package/modules/style.ts
@@ -7,7 +7,7 @@ export type VNodeStyle = Record<string, string> & {
 }
 
 // Bindig `requestAnimationFrame` like this fixes a bug in IE/Edge. See #360 and #409.
-var raf = (typeof window !== 'undefined' && (window.requestAnimationFrame).bind(window)) || setTimeout
+var raf = (typeof window !== 'undefined' && typeof window.requestAnimationFrame !== 'undefined' && (window.requestAnimationFrame).bind(window)) || setTimeout
 var nextFrame = function (fn: any) {
   raf(function () {
     raf(fn)


### PR DESCRIPTION
The current state of style module can crash if running in some environments which have no `window.requestAnimationFrame` function. So, we should add an additional check for it.