### PR TITLE
update checked property based on current element value. fixes #950

### DIFF
--- a/src/modules/props.ts
+++ b/src/modules/props.ts
@@ -25,8 +25,6 @@ function updateProps(oldVnode: VNode, vnode: VNode): void {
     cur = props[key];
     old = oldProps[key];
 
-    shouldUpdate = false;
-
     // DOM INPUT.value should never be updated when it matches the new vnode.
     // typing into an INPUT with a sync event handler cause a render (such as for
     // validation feedback) where setting INPUT.value also pushes the cursor to the end

--- a/src/modules/props.ts
+++ b/src/modules/props.ts
@@ -7,21 +7,44 @@ function updateProps(oldVnode: VNode, vnode: VNode): void {
   let key: string;
   let cur: any;
   let old: any;
+  let shouldUpdate: boolean;
   const elm = vnode.elm;
   let oldProps = (oldVnode.data as VNodeData).props;
   let props = (vnode.data as VNodeData).props;
 
-  if (!oldProps && !props) return;
-  if (oldProps === props) return;
+  if (!oldProps && !props)
+    return;
+
+  if (oldProps === props)
+    return;
+
   oldProps = oldProps || {};
   props = props || {};
 
   for (key in props) {
     cur = props[key];
     old = oldProps[key];
-    if (old !== cur && (key !== "value" || (elm as any)[key] !== cur)) {
+
+    shouldUpdate = false;
+
+    // DOM INPUT.value should never be updated when it matches the new vnode.
+    // typing into an INPUT with a sync event handler cause a render (such as for
+    // validation feedback) where setting INPUT.value also pushes the cursor to the end
+    // of the input. fixes #71, partially fixes #63
+    if (key === 'value')
+      shouldUpdate = (old !== cur) && ((elm as any)[key] !== cur);
+
+    // DOM INPUT.checked is a boolean property. The element's internal value should be
+    // used for comparison. fixes #950
+    else if (key === 'checked')
+      shouldUpdate = (elm as any)[key] !== cur;
+
+    else
+      shouldUpdate = (old !== cur);
+
+
+    if (shouldUpdate)
       (elm as any)[key] = cur;
-    }
   }
 }
 


### PR DESCRIPTION
This is the same exact logic that @Fresheyeball added in #951 but refactored in an attempt to make the logic more clear around _why_ the `value` and `checked` properties are treated a bit differently.