### PR TITLE
docs: add additional JSX usage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ not the class should stay or go on the vnode.
 h("a", { class: { active: true, selected: false } }, "Toggle");
 ```
 
-In JSX, you can use the `class` key.
+In JSX, you can use the `class` prop.
 
 ```jsx
 <div class={{ "foo": true, "bar": true }} />
@@ -410,7 +410,7 @@ Allows you to set properties on DOM elements.
 h("a", { props: { href: "/foo" } }, "Go to Foo");
 ```
 
-In JSX, you can use the `props` key.
+In JSX, you can use the `props` prop.
 
 ```jsx
 <input props={{ name: "foo" }} />
@@ -433,7 +433,7 @@ Same as props, but set attributes instead of properties on DOM elements.
 h("a", { attrs: { href: "/foo" } }, "Go to Foo");
 ```
 
-In JSX, you can use the `attrs` key.
+In JSX, you can use the `attrs` prop.
 
 ```jsx
 <div attrs={{ 'aria-label': "I'm a div" }} />
@@ -463,7 +463,7 @@ Allows you to set custom data attributes (`data-*`) on DOM elements. These can t
 h("button", { dataset: { action: "reset" } }, "Reset");
 ```
 
-In JSX, you can use the `dataset` key.
+In JSX, you can use the `dataset` prop.
 
 ```jsx
 <div dataset={{ foo: "bar" }} />
@@ -825,7 +825,7 @@ import { jsx } from "snabbdom";
 
 const node = (
   <div>
-    <span>I was created with JSX.</span>
+    <span>I was created with JSX</span>
   </div>
 );
 ```

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ modules.
 
 ## Modules documentation
 
-This describes the core modules. All modules are optional.
+This describes the core modules. All modules are optional. JSX examples assume you're using the [`jsx` pragma](#jsx) provided by this library.
 
 ### The class module
 
@@ -395,12 +395,26 @@ not the class should stay or go on the vnode.
 h("a", { class: { active: true, selected: false } }, "Toggle");
 ```
 
+In JSX, you can use the `class` key.
+
+```jsx
+<div class={{ "foo": true, "bar": true }} />
+// Renders as: <div class="foo bar"></div>
+```
+
 ### The props module
 
 Allows you to set properties on DOM elements.
 
 ```mjs
 h("a", { props: { href: "/foo" } }, "Go to Foo");
+```
+
+In JSX, you can use the `props` key.
+
+```jsx
+<input props={{ name: "foo" }} />
+// Renders as: <input name="foo" /> with input.name === "foo"
 ```
 
 Properties can only be set. Not removed. Even though browsers allow addition and
@@ -417,6 +431,13 @@ Same as props, but set attributes instead of properties on DOM elements.
 
 ```mjs
 h("a", { attrs: { href: "/foo" } }, "Go to Foo");
+```
+
+In JSX, you can use the `attrs` key.
+
+```jsx
+<div attrs={{ 'aria-label': "I'm a div" }} />
+// Renders as: <div aria-label="I'm a div"></div>
 ```
 
 Attributes are added and updated using `setAttribute`. In case of an
@@ -440,6 +461,13 @@ Allows you to set custom data attributes (`data-*`) on DOM elements. These can t
 
 ```mjs
 h("button", { dataset: { action: "reset" } }, "Reset");
+```
+
+In JSX, you can use the `dataset` key.
+
+```jsx
+<div dataset={{ foo: "bar" }} />
+// Renders as: <div data-foo="bar"></div>
 ```
 
 ### The style module
@@ -586,7 +614,7 @@ express that by supplying an array at the named event property. The
 first element in the array should be a function that will be invoked
 with the value in the second element once the event occurs.
 
-```mjs
+```mjse
 function clickHandler(number) {
   console.log("button " + number + " was clicked!");
 }
@@ -790,14 +818,14 @@ Add the following options to your babel configuration:
 }
 ```
 
-Then make sure that you use the `.jsx` file extension and import the `jsx` function at the top of the file:
+Then import the `jsx` function at the top of the file:
 
 ```jsx
 import { jsx } from "snabbdom";
 
 const node = (
   <div>
-    <span>I was created with JSX</span>
+    <span>I was created with JSX.</span>
   </div>
 );
 ```
@@ -837,8 +865,6 @@ For example `h('div', {props: {className: 'container'}}, [...])` will produce a 
   },
 });
 ```
-
-as its `.data` object.
 
 ### children : Array<vnode>
 

--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ express that by supplying an array at the named event property. The
 first element in the array should be a function that will be invoked
 with the value in the second element once the event occurs.
 
-```mjse
+```mjs
 function clickHandler(number) {
   console.log("button " + number + " was clicked!");
 }
@@ -865,6 +865,8 @@ For example `h('div', {props: {className: 'container'}}, [...])` will produce a 
   },
 });
 ```
+
+as its `.data` object.
 
 ### children : Array<vnode>
 

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ not the class should stay or go on the vnode.
 h("a", { class: { active: true, selected: false } }, "Toggle");
 ```
 
-In JSX, you can use the `class` prop.
+In JSX, you can use `class` like this:
 
 ```jsx
 <div class={{ "foo": true, "bar": true }} />
@@ -410,7 +410,7 @@ Allows you to set properties on DOM elements.
 h("a", { props: { href: "/foo" } }, "Go to Foo");
 ```
 
-In JSX, you can use the `props` prop.
+In JSX, you can use `props` like this:
 
 ```jsx
 <input props={{ name: "foo" }} />
@@ -433,7 +433,7 @@ Same as props, but set attributes instead of properties on DOM elements.
 h("a", { attrs: { href: "/foo" } }, "Go to Foo");
 ```
 
-In JSX, you can use the `attrs` prop.
+In JSX, you can use `attrs` like this:
 
 ```jsx
 <div attrs={{ 'aria-label': "I'm a div" }} />
@@ -463,7 +463,7 @@ Allows you to set custom data attributes (`data-*`) on DOM elements. These can t
 h("button", { dataset: { action: "reset" } }, "Reset");
 ```
 
-In JSX, you can use the `dataset` prop.
+In JSX, you can use `dataset` like this:
 
 ```jsx
 <div dataset={{ foo: "bar" }} />
@@ -487,6 +487,17 @@ h(
   },
   "Say my name, and every colour illuminates"
 );
+```
+
+In JSX, you can use `style` like this:
+
+```jsx
+<div style={{
+  border: "1px solid #bada55",
+  color: "#c0ffee",
+  fontWeight: "bold",
+}} />
+// Renders as: <div style="border: 1px solid #bada55; color: #c0ffee; font-weight: bold"></div>
 ```
 
 Note that the style module does not remove style attributes if they
@@ -599,6 +610,12 @@ function clickHandler(ev) {
   console.log("got clicked");
 }
 h("div", { on: { click: clickHandler } });
+```
+
+In JSX, you can use `on` like this:
+
+```js
+<div on={{ click: clickHandler }} />
 ```
 
 Very often, however, you're not really interested in the event object


### PR DESCRIPTION
Motivation: I recently tried using the JSX pragma in a project and it wasn't clear why Snabbdom wasn't processing my element props via the appropriate module (class, style, props, attributes, etc). But I eventually figured it out, and figured it'd be worth adding here.

Main additions are:
- adds JSX examples to module sections
- removes file extension requirement in babel config section (babel only cares about the pragma, not the extension, to my knowledge).

Is it worth adding these? Should there be other clarifications/additions I didn't cover? Thanks.