### PR TITLE
Support DocumentFragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ patch(vnode, newVnode); // Snabbdom efficiently updates the old view to the new 
   - [`patch`](#patch)
     - [Unmounting](#unmounting)
   - [`h`](#h)
+  - [`fragment`](#fragment-experimental) (experimental)
   - [`tovnode`](#tovnode)
   - [Hooks](#hooks)
     - [Overview](#overview)
@@ -229,6 +230,27 @@ const vnode = h("div", { style: { color: "#000" } }, [
   h("h1", "Headline"),
   h("p", "A paragraph"),
 ]);
+```
+
+### `fragment` (experimental)
+
+Caution: This feature is currently experimental and must be opted in.
+Its API may be changed without an major version bump.
+
+```mjs
+const patch = init(modules, undefined, {
+  experimental: {
+    fragments: true,
+  },
+});
+```
+
+Creates a virtual node that will be converted to a document fragment containing the given children.
+
+```mjs
+import { fragment, h } from "snabbdom";
+
+const vnode = fragment(["I am", h("span", [" a", " fragment"])]);
 ```
 
 ### `tovnode`
@@ -398,7 +420,7 @@ h("a", { class: { active: true, selected: false } }, "Toggle");
 In JSX, you can use `class` like this:
 
 ```jsx
-<div class={{ "foo": true, "bar": true }} />
+<div class={{ foo: true, bar: true }} />
 // Renders as: <div class="foo bar"></div>
 ```
 
@@ -436,7 +458,7 @@ h("a", { attrs: { href: "/foo" } }, "Go to Foo");
 In JSX, you can use `attrs` like this:
 
 ```jsx
-<div attrs={{ 'aria-label': "I'm a div" }} />
+<div attrs={{ "aria-label": "I'm a div" }} />
 // Renders as: <div aria-label="I'm a div"></div>
 ```
 
@@ -492,11 +514,13 @@ h(
 In JSX, you can use `style` like this:
 
 ```jsx
-<div style={{
-  border: "1px solid #bada55",
-  color: "#c0ffee",
-  fontWeight: "bold",
-}} />
+<div
+  style={{
+    border: "1px solid #bada55",
+    color: "#c0ffee",
+    fontWeight: "bold",
+  }}
+/>
 // Renders as: <div style="border: 1px solid #bada55; color: #c0ffee; font-weight: bold"></div>
 ```
 

--- a/src/h.ts
+++ b/src/h.ts
@@ -86,3 +86,28 @@ export function h(sel: any, b?: any, c?: any): VNode {
   }
   return vnode(sel, data, children, text, undefined);
 }
+
+/**
+ * @experimental
+ */
+export function fragment(children: VNodeChildren): VNode {
+  let c: any;
+  let text: any;
+
+  if (is.array(children)) {
+    c = children;
+  } else if (is.primitive(c)) {
+    text = children;
+  } else if (c && c.sel) {
+    c = [children];
+  }
+
+  if (c !== undefined) {
+    for (let i = 0; i < c.length; ++i) {
+      if (is.primitive(c[i]))
+        c[i] = vnode(undefined, undefined, undefined, c[i], undefined);
+    }
+  }
+
+  return vnode(undefined, {}, c, text, undefined);
+}

--- a/src/htmldomapi.ts
+++ b/src/htmldomapi.ts
@@ -30,6 +30,11 @@ export interface DOMAPI {
   isElement: (node: Node) => node is Element;
   isText: (node: Node) => node is Text;
   isComment: (node: Node) => node is Comment;
+  /**
+   * @experimental
+   * @todo Make it required when the fragment is considered stable.
+   */
+  isDocumentFragment?: (node: Node) => node is DocumentFragment;
 }
 
 function createElement(
@@ -107,6 +112,10 @@ function isComment(node: Node): node is Comment {
   return node.nodeType === 8;
 }
 
+function isDocumentFragment(node: Node): node is DocumentFragment {
+  return node.nodeType === 11;
+}
+
 export const htmlDomApi: DOMAPI = {
   createElement,
   createElementNS,
@@ -124,4 +133,5 @@ export const htmlDomApi: DOMAPI = {
   isElement,
   isText,
   isComment,
+  isDocumentFragment,
 };

--- a/src/htmldomapi.ts
+++ b/src/htmldomapi.ts
@@ -8,6 +8,11 @@ export interface DOMAPI {
     qualifiedName: string,
     options?: ElementCreationOptions
   ) => Element;
+  /**
+   * @experimental
+   * @todo Make it required when the fragment is considered stable.
+   */
+  createDocumentFragment?: () => DocumentFragment;
   createTextNode: (text: string) => Text;
   createComment: (text: string) => Comment;
   insertBefore: (
@@ -40,6 +45,10 @@ function createElementNS(
   options?: ElementCreationOptions
 ): Element {
   return document.createElementNS(namespaceURI, qualifiedName, options);
+}
+
+function createDocumentFragment(): DocumentFragment {
+  return document.createDocumentFragment();
 }
 
 function createTextNode(text: string): Text {
@@ -102,6 +111,7 @@ export const htmlDomApi: DOMAPI = {
   createElement,
   createElementNS,
   createTextNode,
+  createDocumentFragment,
   createComment,
   insertBefore,
   removeChild,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
   ArrayOrElement,
   VNodeChildren,
   h,
+  fragment,
 } from "./h";
 
 // types

--- a/src/init.ts
+++ b/src/init.ts
@@ -31,8 +31,18 @@ function documentFragmentIsNotSupported(): never {
   throw new Error("The document fragment is not supported on this platform.");
 }
 
-function isElement(api: DOMAPI, vnode: Element | VNode): vnode is Element {
+function isElement(
+  api: DOMAPI,
+  vnode: Element | DocumentFragment | VNode
+): vnode is Element {
   return api.isElement(vnode as any);
+}
+
+function isDocumentFragment(
+  api: DOMAPI,
+  vnode: DocumentFragment | VNode
+): vnode is DocumentFragment {
+  return api.isDocumentFragment(vnode as any);
 }
 
 type KeyToIndexMap = { [key: string]: number };
@@ -114,6 +124,10 @@ export function init(
       undefined,
       elm
     );
+  }
+
+  function emptyDocumentFragmentAt(frag: DocumentFragment) {
+    return vnode(undefined, {}, [], undefined, frag);
   }
 
   function createRmCb(childElm: Node, listeners: number) {
@@ -394,13 +408,18 @@ export function init(
     hook?.postpatch?.(oldVnode, vnode);
   }
 
-  return function patch(oldVnode: VNode | Element, vnode: VNode): VNode {
+  return function patch(
+    oldVnode: VNode | Element | DocumentFragment,
+    vnode: VNode
+  ): VNode {
     let i: number, elm: Node, parent: Node;
     const insertedVnodeQueue: VNodeQueue = [];
     for (i = 0; i < cbs.pre.length; ++i) cbs.pre[i]();
 
     if (isElement(api, oldVnode)) {
       oldVnode = emptyNodeAt(oldVnode);
+    } else if (isDocumentFragment(api, oldVnode)) {
+      oldVnode = emptyDocumentFragmentAt(oldVnode);
     }
 
     if (sameVnode(oldVnode, vnode)) {

--- a/src/vnode.ts
+++ b/src/vnode.ts
@@ -40,7 +40,7 @@ export function vnode(
   data: any | undefined,
   children: Array<VNode | string> | undefined,
   text: string | undefined,
-  elm: Element | Text | undefined
+  elm: Element | DocumentFragment | Text | undefined
 ): VNode {
   const key = data === undefined ? undefined : data.key;
   return { sel, data, children, text, elm, key };

--- a/test/unit/core.ts
+++ b/test/unit/core.ts
@@ -1101,6 +1101,17 @@ describe("snabbdom", function () {
       assert.strictEqual(elm.nodeType, document.DOCUMENT_FRAGMENT_NODE);
       assert.strictEqual(elm.textContent, "fragment again");
     });
+    it("allows a document fragment as a container", function () {
+      const vnode0 = document.createDocumentFragment();
+      const vnode1 = fragment(["I", "am", "a", h("span", ["fragment"])]);
+      const vnode2 = h("div", "I am an element");
+
+      elm = patch(vnode0, vnode1).elm;
+      assert.strictEqual(elm.nodeType, document.DOCUMENT_FRAGMENT_NODE);
+
+      elm = patch(vnode1, vnode2).elm;
+      assert.strictEqual(elm.tagName, "DIV");
+    });
   });
   describe("hooks", function () {
     describe("element hooks", function () {

--- a/test/unit/core.ts
+++ b/test/unit/core.ts
@@ -20,11 +20,16 @@ import {
   DestroyHook,
   UpdateHook,
   Key,
+  fragment,
 } from "../../src/index";
 
 const hasSvgClassList = "classList" in SVGElement.prototype;
 
-const patch = init([classModule, propsModule, eventListenersModule]);
+const patch = init(
+  [classModule, propsModule, eventListenersModule],
+  undefined,
+  { experimental: { fragments: true } }
+);
 
 function prop<T>(name: string) {
   return function (obj: { [index: string]: T }) {
@@ -266,6 +271,15 @@ describe("snabbdom", function () {
       elm = patch(vnode0, h("!", "test")).elm;
       assert.strictEqual(elm.nodeType, document.COMMENT_NODE);
       assert.strictEqual(elm.textContent, "test");
+    });
+  });
+  describe("created document fragment", function () {
+    it("is an instance of DocumentFragment", function () {
+      const vnode1 = fragment(["I am", h("span", [" a", " fragment"])]);
+
+      elm = patch(vnode0, vnode1).elm;
+      assert.strictEqual(elm.nodeType, document.DOCUMENT_FRAGMENT_NODE);
+      assert.strictEqual(elm.textContent, "I am a fragment");
     });
   });
   describe("patching an element", function () {
@@ -1068,6 +1082,24 @@ describe("snabbdom", function () {
         elm = patch(vnode2, vnode3).elm;
         assert.deepEqual(map(inner, elm.children), ["2", "1"]);
       });
+    });
+  });
+  describe("patching a fragment", function () {
+    it("can patch on document fragments", function () {
+      const vnode1 = fragment(["I am", h("span", [" a", " fragment"])]);
+      const vnode2 = h("div", ["I am an element"]);
+      const vnode3 = fragment(["fragment ", "again"]);
+
+      elm = patch(vnode0, vnode1).elm;
+      assert.strictEqual(elm.nodeType, document.DOCUMENT_FRAGMENT_NODE);
+
+      elm = patch(vnode1, vnode2).elm;
+      assert.strictEqual(elm.tagName, "DIV");
+      assert.strictEqual(elm.textContent, "I am an element");
+
+      elm = patch(vnode2, vnode3).elm;
+      assert.strictEqual(elm.nodeType, document.DOCUMENT_FRAGMENT_NODE);
+      assert.strictEqual(elm.textContent, "fragment again");
     });
   });
   describe("hooks", function () {


### PR DESCRIPTION
# Synopsis

This pull request introduces an ability to handle [`DocumentFragment`](https://developer.mozilla.org/docs/Web/API/DocumentFragment), which is another notable subclass of [`Node`](https://developer.mozilla.org/en-US/docs/Web/API/Node) other than [`Element`](https://developer.mozilla.org/docs/Web/API/Element) nor [`Text`](https://developer.mozilla.org/docs/Web/API/Text).
It allows a function to return multiple VNodes without an extra wrapper element, resolving #560.

`fragment` function is now exported from the entry point.
There is, however, a room for discussion on the design of the API.

The second commit will allow us to use a `DocumentFragment` as a container, in addition to an `Element`.

# Possible design choices

## a) Public API

In the current implementation I chose a2), but of course it's okay to change it along with the discussion before merging.

### a1) Extend `h` function so that it can create a fragment

Looking around the documents and test cases, there is no doubt that the most popular way to produce a VNode is to call `h` function.
This is why adding such an ability to `h` function can be a good choice.

There are still some possible APIs:

- a11) `h(children)`
  - [`react-hyperscript`](https://github.com/mlmorg/react-hyperscript) uses this.
- a12) `h(undefined, children)`
- a13) `h('', children)`

#### Pros

- No extra import is needed other than `h`

#### Cons

- AFAIK this doesn't exist in the original hyperscript notation
  - **UPDATE:** I've noticed that we already have a syntactic extension to the original hyperscript: `h('!', ...)`

### a2) Provide a function other than `h`

As the original hyperscript notation does not consider fragments, it may be undesirable to change the API of `h` function.
We may want to export different function other than `h` for this reason.

In the current implementation, I named it `fragment`, but to be honest I'm not sure what is the good name for this function.

If we also want to support JSX fragments (which I'm working on in #974), `Fragment` (with a capital "F") should be avoided, as it is a conventional name for it.

#### Pros

- Does not break the original API of `h` function

#### Cons

- It must be named
- Consumers have to add an extra import for it

### a3) Do nothing

Of course VNodes can also be created with `vnode` function, `vnode(undefined, {}, children, undefined, undefined)` will just do.

#### Pros

- No new API have to be introduced
  - That is, we can defer the decision. Maybe we can merge this time and continue to discuss what the desirable API look like later on.

#### Cons

- It may look like a "hidden" API
- Children must be normalized manually before passing them to `vnode`

## b) Internal representation

It is relatively minor topic compared to what the public API should look like, but we also have to decide how a VNode representing a `DocumentFragment` is encoded.

In the current implementation I chose b1), but there are no profound reasons for this choice.

Please note that both b1) and b2) are assignable to the current implementation of `VNode` type.

### b1) `{ sel: undefined, children: [...] }`

Currently `VNode` type is defined like this:
https://github.com/snabbdom/snabbdom/blob/27e9c4d5dca62b6dabf9ac23efb95f1b6045b2df/src/vnode.ts#L12-L19

In spite of its assignability to `VNode` type, `{ sel: undefined, children: [...] }` is not a first-class citizen of Snabbdom, and will cause a runtime error.
This option will give a correct semantics to such an empty seat.

### b2) `{ sel: '', children: [...] }`

I saw @staltz passing an empty string to the first argument of `vnode` function in #320, perhaps meaning "whatever".
As this line is still alive in the code base, it may be more conventional.

https://github.com/snabbdom/snabbdom/blob/27e9c4d5dca62b6dabf9ac23efb95f1b6045b2df/src/tovnode.ts#L35

# Breaking changes

This is technically breaking, as `DOMAPI` now requires `createDocumentFragment` and `isDocumentFragment` method.