### PR TITLE
Export `Options` type from the entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // core
 export { DOMAPI, htmlDomApi } from "./htmldomapi";
-export { init } from "./init";
+export { init, Options } from "./init";
 export { ThunkData, Thunk, ThunkFn, thunk } from "./thunk";
 export { Key, VNode, VNodeData, vnode } from "./vnode";
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -78,7 +78,7 @@ const hooks: Array<keyof Module> = [
 ];
 
 // TODO Should `domApi` be put into this in the next major version bump?
-type Options = {
+export type Options = {
   experimental?: {
     fragments?: boolean;
   };


### PR DESCRIPTION
This is a speculative pull request addressing https://github.com/snabbdom/snabbdom/pull/975#issuecomment-997180772, so please feel free to close this if you don't need this.

---

Exporting the `Options` type, so that other libraries in the ecosystem (e.g. `@cycle/dom`) can depend on it.