### PR TITLE
fix(fragment): fixed patching fragment nodes

### DIFF
--- a/src/htmldomapi.ts
+++ b/src/htmldomapi.ts
@@ -75,6 +75,14 @@ function insertBefore(
   newNode: Node,
   referenceNode: Node | null
 ): void {
+  if (isDocumentFragment(parentNode)) {
+    let node: Node | null = parentNode;
+    while (node && isDocumentFragment(node)) {
+      const fragment = parseFragment(node);
+      node = fragment.parent;
+    }
+    parentNode = node ?? parentNode;
+  }
   if (isDocumentFragment(newNode)) {
     newNode = parseFragment(newNode, parentNode);
   }
@@ -98,7 +106,8 @@ function appendChild(node: Node, child: Node): void {
 function parentNode(node: Node): Node | null {
   if (isDocumentFragment(node)) {
     while (node && isDocumentFragment(node)) {
-      node = (node as any).parent;
+      const fragment = parseFragment(node);
+      node = fragment.parent as Node;
     }
     return node ?? null;
   }

--- a/src/htmldomapi.ts
+++ b/src/htmldomapi.ts
@@ -69,6 +69,9 @@ function insertBefore(
   newNode: Node,
   referenceNode: Node | null
 ): void {
+  if (isDocumentFragment(newNode)) {
+    (newNode as any).parent = parentNode;
+  }
   parentNode.insertBefore(newNode, referenceNode);
 }
 
@@ -81,6 +84,12 @@ function appendChild(node: Node, child: Node): void {
 }
 
 function parentNode(node: Node): Node | null {
+  if (isDocumentFragment(node)) {
+    while (node && isDocumentFragment(node)) {
+      node = (node as any).parent;
+    }
+    return node ?? null;
+  }
   return node.parentNode;
 }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -271,6 +271,7 @@ export function init(
           }
         } else if (ch.children) {
           // Fragment node
+          invokeDestroyHook(ch);
           removeVnodes(
             parentElm,
             ch.children as VNode[],

--- a/src/init.ts
+++ b/src/init.ts
@@ -20,8 +20,12 @@ function sameVnode(vnode1: VNode, vnode2: VNode): boolean {
   const isSameKey = vnode1.key === vnode2.key;
   const isSameIs = vnode1.data?.is === vnode2.data?.is;
   const isSameSel = vnode1.sel === vnode2.sel;
+  const isSameTextOrFragment =
+    !vnode1.sel && vnode1.sel === vnode2.sel
+      ? typeof vnode1.text === typeof vnode2.text
+      : true;
 
-  return isSameSel && isSameKey && isSameIs;
+  return isSameSel && isSameKey && isSameIs && isSameTextOrFragment;
 }
 
 /**
@@ -192,13 +196,12 @@ export function init(
         }
       }
     } else if (options?.experimental?.fragments && vnode.children) {
-      const children = vnode.children;
       vnode.elm = (
         api.createDocumentFragment ?? documentFragmentIsNotSupported
       )();
       for (i = 0; i < cbs.create.length; ++i) cbs.create[i](emptyNode, vnode);
-      for (i = 0; i < children.length; ++i) {
-        const ch = children[i];
+      for (i = 0; i < vnode.children.length; ++i) {
+        const ch = vnode.children[i];
         if (ch != null) {
           api.appendChild(
             vnode.elm,
@@ -388,14 +391,14 @@ export function init(
     const hook = vnode.data?.hook;
     hook?.prepatch?.(oldVnode, vnode);
     const elm = (vnode.elm = oldVnode.elm)!;
-    const oldCh = oldVnode.children as VNode[];
-    const ch = vnode.children as VNode[];
     if (oldVnode === vnode) return;
     if (vnode.data !== undefined) {
       for (let i = 0; i < cbs.update.length; ++i)
         cbs.update[i](oldVnode, vnode);
       vnode.data.hook?.update?.(oldVnode, vnode);
     }
+    const oldCh = oldVnode.children as VNode[];
+    const ch = vnode.children as VNode[];
     if (isUndef(vnode.text)) {
       if (isDef(oldCh) && isDef(ch)) {
         if (oldCh !== ch) updateChildren(elm, oldCh, ch, insertedVnodeQueue);

--- a/src/init.ts
+++ b/src/init.ts
@@ -266,6 +266,14 @@ export function init(
           } else {
             rm();
           }
+        } else if (ch.children) {
+          // Fragment node
+          removeVnodes(
+            parentElm,
+            ch.children as VNode[],
+            0,
+            ch.children.length - 1
+          );
         } else {
           // Text node
           api.removeChild(parentElm, ch.elm!);

--- a/test/unit/core.ts
+++ b/test/unit/core.ts
@@ -1110,20 +1110,35 @@ describe("snabbdom", function () {
   });
   describe("patching a fragment", function () {
     it("can patch on document fragments", function () {
+      let firstChild: HTMLElement;
+      const root = document.createElement("div");
       const vnode1 = fragment(["I am", h("span", [" a", " fragment"])]);
       const vnode2 = h("div", ["I am an element"]);
       const vnode3 = fragment(["fragment ", "again"]);
 
+      root.appendChild(vnode0);
+      firstChild = root.firstChild as HTMLElement;
+      assert.strictEqual(firstChild, vnode0);
+
       elm = patch(vnode0, vnode1).elm;
+      firstChild = root.firstChild as HTMLElement;
+      assert.strictEqual(firstChild.textContent, "I am");
       assert.strictEqual(elm.nodeType, document.DOCUMENT_FRAGMENT_NODE);
+      assert.strictEqual(elm.parent, root);
 
       elm = patch(vnode1, vnode2).elm;
+      firstChild = root.firstChild as HTMLElement;
+      assert.strictEqual(firstChild.tagName, "DIV");
+      assert.strictEqual(firstChild.textContent, "I am an element");
       assert.strictEqual(elm.tagName, "DIV");
       assert.strictEqual(elm.textContent, "I am an element");
+      assert.strictEqual(elm.parentNode, root);
 
       elm = patch(vnode2, vnode3).elm;
+      firstChild = root.firstChild as HTMLElement;
       assert.strictEqual(elm.nodeType, document.DOCUMENT_FRAGMENT_NODE);
-      assert.strictEqual(elm.textContent, "fragment again");
+      assert.strictEqual(firstChild.textContent, "fragment ");
+      assert.strictEqual(elm.parent, root);
     });
     it("allows a document fragment as a container", function () {
       const vnode0 = document.createDocumentFragment();


### PR DESCRIPTION
Fix for the bug mentioned on https://github.com/snabbdom/snabbdom/issues/1014.

To fix the bug, it was needed to keep the Ref of the parent that the `DocumentFragment` was appended to. So the easiest fix was to create a `parent` property on fragment ref inside the `insertBefore` hook (maybe we'll need to add it to other domApi hooks too, but it's working just with this one).

The tests for fragment patch weren't right, even with success it was bugging on real browsers. So I fixed the tests to reproduce the bug.

I will be happy to help with any questions that come out.
