### PR TITLE
fix: repair test to reveal possible bug

### DIFF
--- a/test/unit/core.ts
+++ b/test/unit/core.ts
@@ -379,7 +379,7 @@ describe("snabbdom", function () {
       const vnode1 = h("a", { props: { src: "http://other/" } });
       const vnode2 = h("a");
       patch(vnode0, vnode1);
-      patch(vnode1, vnode2);
+      elm = patch(vnode1, vnode2).elm;
       assert.strictEqual(elm.src, undefined);
     });
     it("cannot remove native props", function () {


### PR DESCRIPTION
Hi,

I'm working on a port of Snabbdom to Scala.js (the repo is still private) and this just popped up. I think this test only passed by accident b/c the underling `Element` is not actually shared in the first patch from `div` to `a`. With this change the test actually fails, which makes sense I think b/c the props module never deletes old properties from the underlying `Element`.

