### PR TITLE
Better style api for types

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,10 @@ h(
 #### Delayed properties
 
 You can specify properties as being delayed. Whenever these properties
-change, the change is not applied until after the next frame.
+change, the change is not applied until after the next frame. If a base
+property that is also a delayed propery, the base change will be applied
+immediately, and the the delayed change rescheduled for the next frame.
+Delayed properties that are removed are applied immediately.
 
 ```mjs
 h(
@@ -586,24 +589,6 @@ h(
 ```
 
 This makes it easy to declaratively animate the removal of elements.
-
-The `all` value of `transition-property` is not supported.
-
-#### Set properties on `destroy`
-
-```mjs
-h(
-  "span",
-  {
-    style: {
-      opacity: "1",
-      transition: "opacity 1s",
-      destroy: { opacity: "0" },
-    },
-  },
-  "It's better to fade out than to burn away"
-);
-```
 
 The `all` value of `transition-property` is not supported.
 

--- a/README.md
+++ b/README.md
@@ -503,9 +503,11 @@ h(
   "span",
   {
     style: {
-      border: "1px solid #bada55",
-      color: "#c0ffee",
-      fontWeight: "bold",
+      base: {
+        border: "1px solid #bada55",
+        color: "#c0ffee",
+        fontWeight: "bold",
+      },
     },
   },
   "Say my name, and every colour illuminates"
@@ -517,9 +519,11 @@ In JSX, you can use `style` like this:
 ```jsx
 <div
   style={{
-    border: "1px solid #bada55",
-    color: "#c0ffee",
-    fontWeight: "bold",
+    base: {
+      border: "1px solid #bada55",
+      color: "#c0ffee",
+      fontWeight: "bold",
+    }
   }}
 />
 // Renders as: <div style="border: 1px solid #bada55; color: #c0ffee; font-weight: bold"></div>
@@ -534,7 +538,7 @@ with `--`
 h(
   "div",
   {
-    style: { "--warnColor": "yellow" },
+    style: { base: { "--warnColor": "yellow" } },
   },
   "Warning"
 );
@@ -553,9 +557,13 @@ h(
   "span",
   {
     style: {
-      opacity: "0",
-      transition: "opacity 1s",
-      delayed: { opacity: "1" },
+      {
+        base: {
+          opacity: "0",
+          transition: "opacity 1s",
+        }
+        delayed: { opacity: "1" },
+      }
     },
   },
   "Imma fade right in!"
@@ -578,8 +586,10 @@ h(
   "span",
   {
     style: {
-      opacity: "1",
-      transition: "opacity 1s",
+      base: {
+        opacity: "1",
+        transition: "opacity 1s",
+      }
       remove: { opacity: "0" },
     },
   },

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ In JSX, you can use `style` like this:
       border: "1px solid #bada55",
       color: "#c0ffee",
       fontWeight: "bold",
-    }
+    },
   }}
 />
 // Renders as: <div style="border: 1px solid #bada55; color: #c0ffee; font-weight: bold"></div>

--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ patch(vnode, newVnode); // Snabbdom efficiently updates the old view to the new 
     - [Custom properties (CSS variables)](#custom-properties-css-variables)
     - [Delayed properties](#delayed-properties)
     - [Set properties on `remove`](#set-properties-on-remove)
-    - [Set properties on `destroy`](#set-properties-on-destroy)
   - [The eventlisteners module](#the-eventlisteners-module)
 - [SVG](#svg)
   - [Classes in SVG Elements](#classes-in-svg-elements)

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export { Classes, classModule } from "./modules/class";
 export { Dataset, datasetModule } from "./modules/dataset";
 export { On, eventListenersModule } from "./modules/eventlisteners";
 export { Props, propsModule } from "./modules/props";
-export { VNodeStyle, styleModule } from "./modules/style";
+export { VNodeStyle, StyleObject, styleModule } from "./modules/style";
 
 // JSX
 export {

--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -17,7 +17,7 @@ const raf =
     window.requestAnimationFrame.bind(window)) ||
   setTimeout;
 
-const nextFrame = function (fn: () => void) {
+const nextFrame = function (fn: () => void): void {
   raf(function () {
     raf(fn);
   });
@@ -200,19 +200,16 @@ function applyRemoveStyle(vnode: VNode, rm: () => void): void {
   Object.keys(style).forEach((key) => {
     applied.push(key);
     elm.style[key as any] = style[key]!;
-  })
+  });
   const compStyle = getComputedStyle(elm);
   const props = compStyle.transitionProperty.split(", ");
   for (let i = 0; i < props.length; ++i) {
     if (applied.indexOf(props[i]) !== -1) amount++;
   }
-  elm.addEventListener(
-    "transitionend",
-    function (ev: TransitionEvent) {
-      if (ev.target === elm) --amount;
-      if (amount === 0) rm();
-    }
-  );
+  elm.addEventListener("transitionend", function (ev: TransitionEvent) {
+    if (ev.target === elm) --amount;
+    if (amount === 0) rm();
+  });
 }
 
 function forceReflow() {

--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -47,7 +47,7 @@ const areObjectsDifferent = (a: StyleObject, b: StyleObject): boolean => {
   );
 };
 
-const selectBaseStyles = (input: StyleObject) => {
+const selectBaseStyles = (input: StyleObject): StyleObject => {
   const newStyles: StyleObject = {};
   Object.keys(input).forEach((key) => {
     if (key === DELAYED || key === REMOVE) return;

--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -1,7 +1,7 @@
 import { VNode, VNodeData } from "../vnode";
 import { Module } from "./module";
 
-export type StyleObject = Partial<Record<string, string>>;
+export type StyleObject = Partial<Record<string, string | number>>;
 
 export type VNodeStyle = {
   base?: StyleObject;
@@ -58,7 +58,7 @@ const selectBaseStyles = (input: VNodeStyle): StyleObject => {
   });
 
   // but anything on an actual `base` property takes priority
-  const base = input.base || {}
+  const base = input.base || {};
   Object.keys(base || {}).forEach((key) => {
     newStyles[key] = base[key]!;
   });
@@ -100,7 +100,9 @@ const scheduleNextFrame = (): void => {
       const { elm, queued } = stylesForElement;
       // update the active styles to match the queued ones
       // note removing styles is done synchronously
-      Object.keys(queued).forEach((key) => addStyle(elm, key, queued[key]!));
+      Object.keys(queued).forEach((key) =>
+        addStyle(elm, key, `${queued[key]!}`)
+      );
 
       stylesForElement.active = stylesForElement.queued;
     });
@@ -179,7 +181,7 @@ const updateStyle = (oldVnode: VNode, vnode: VNode): void => {
   });
 
   Object.keys(stylesToAdd).forEach((key) =>
-    addStyle(elm, key, stylesToAdd[key]!)
+    addStyle(elm, key, `${stylesToAdd[key]!}`)
   );
 
   stylesToRemove.forEach((key) => removeStyle(elm, key));
@@ -208,7 +210,7 @@ function applyRemoveStyle(vnode: VNode, rm: () => void): void {
   const applied: string[] = [];
   Object.keys(style).forEach((key) => {
     applied.push(key);
-    elm.style[key as any] = style[key]!;
+    elm.style[key as any] = `${style[key]!}`;
   });
   const compStyle = getComputedStyle(elm);
   const props = compStyle.transitionProperty.split(", ");

--- a/test/unit/core.ts
+++ b/test/unit/core.ts
@@ -336,10 +336,10 @@ describe("snabbdom", function () {
         h(
           "div",
           {
-            style: { height: "100px", overflowY: "scroll" },
+            style: { base: { height: "100px", overflowY: "scroll" } },
             props: { scrollTop },
           },
-          [h("div", { style: { height: "200px" } })]
+          [h("div", { style: { base: { height: "200px" } } })]
         );
       const vnode1 = view(0);
       const mountPoint = document.body.appendChild(
@@ -409,8 +409,8 @@ describe("snabbdom", function () {
           );
 
           if (!isSafari) {
-            class A extends HTMLParagraphElement {}
-            class B extends HTMLParagraphElement {}
+            class A extends HTMLParagraphElement { }
+            class B extends HTMLParagraphElement { }
 
             before(function () {
               if ("customElements" in window) {
@@ -836,7 +836,7 @@ describe("snabbdom", function () {
         const elms = 14;
         const samples = 5;
         function spanNumWithOpacity(n: number, o: string) {
-          return h("span", { key: n, style: { opacity: o } }, n.toString());
+          return h("span", { key: n, style: { base: { opacity: o } } }, n.toString());
         }
         for (n = 0; n < elms; ++n) {
           arr[n] = n;

--- a/test/unit/core.ts
+++ b/test/unit/core.ts
@@ -409,8 +409,8 @@ describe("snabbdom", function () {
           );
 
           if (!isSafari) {
-            class A extends HTMLParagraphElement { }
-            class B extends HTMLParagraphElement { }
+            class A extends HTMLParagraphElement {}
+            class B extends HTMLParagraphElement {}
 
             before(function () {
               if ("customElements" in window) {
@@ -836,7 +836,11 @@ describe("snabbdom", function () {
         const elms = 14;
         const samples = 5;
         function spanNumWithOpacity(n: number, o: string) {
-          return h("span", { key: n, style: { base: { opacity: o } } }, n.toString());
+          return h(
+            "span",
+            { key: n, style: { base: { opacity: o } } },
+            n.toString()
+          );
         }
         for (n = 0; n < elms; ++n) {
           arr[n] = n;

--- a/test/unit/style.ts
+++ b/test/unit/style.ts
@@ -16,13 +16,16 @@ describe("style", function () {
     vnode0 = elm;
   });
   it("is being styled", function () {
-    elm = patch(vnode0, h("div", { style: { fontSize: "12px" } as any })).elm;
+    elm = patch(
+      vnode0,
+      h("div", { style: { base: { fontSize: "12px" } } })
+    ).elm;
     assert.strictEqual(elm.style.fontSize, "12px");
   });
   it("can be memoized", function () {
     const cachedStyles = { fontSize: "14px", display: "inline" };
-    const vnode1 = h("i", { style: cachedStyles } as any);
-    const vnode2 = h("i", { style: cachedStyles } as any);
+    const vnode1 = h("i", { style: { base: cachedStyles } });
+    const vnode2 = h("i", { style: { base: cachedStyles } });
     elm = patch(vnode0, vnode1).elm;
     assert.strictEqual(elm.style.fontSize, "14px");
     assert.strictEqual(elm.style.display, "inline");
@@ -31,9 +34,15 @@ describe("style", function () {
     assert.strictEqual(elm.style.display, "inline");
   });
   it("updates styles", function () {
-    const vnode1 = h("i", { style: { fontSize: "14px", display: "inline" } as any });
-    const vnode2 = h("i", { style: { fontSize: "12px", display: "block" } as any });
-    const vnode3 = h("i", { style: { fontSize: "10px", display: "block" } as any });
+    const vnode1 = h("i", {
+      style: { base: { fontSize: "14px", display: "inline" } },
+    });
+    const vnode2 = h("i", {
+      style: { base: { fontSize: "12px", display: "block" } },
+    });
+    const vnode3 = h("i", {
+      style: { base: { fontSize: "10px", display: "block" } },
+    });
     elm = patch(vnode0, vnode1).elm;
     assert.strictEqual(elm.style.fontSize, "14px");
     assert.strictEqual(elm.style.display, "inline");
@@ -45,9 +54,9 @@ describe("style", function () {
     assert.strictEqual(elm.style.display, "block");
   });
   it("explicialy removes styles", function () {
-    const vnode1 = h("i", { style: { fontSize: "14px" } as any });
-    const vnode2 = h("i", { style: { fontSize: "" } as any });
-    const vnode3 = h("i", { style: { fontSize: "10px" } as any });
+    const vnode1 = h("i", { style: { base: { fontSize: "14px" } } });
+    const vnode2 = h("i", { style: { base: { fontSize: "" } } });
+    const vnode3 = h("i", { style: { base: { fontSize: "10px" } } });
     elm = patch(vnode0, vnode1).elm;
     assert.strictEqual(elm.style.fontSize, "14px");
     patch(vnode1, vnode2);
@@ -56,9 +65,13 @@ describe("style", function () {
     assert.strictEqual(elm.style.fontSize, "10px");
   });
   it("implicially removes styles from element", function () {
-    const vnode1 = h("div", [h("i", { style: { fontSize: "14px" } as any })]);
+    const vnode1 = h("div", [
+      h("i", { style: { base: { fontSize: "14px" } } }),
+    ]);
     const vnode2 = h("div", [h("i")]);
-    const vnode3 = h("div", [h("i", { style: { fontSize: "10px" } as any })]);
+    const vnode3 = h("div", [
+      h("i", { style: { base: { fontSize: "10px" } } }),
+    ]);
     patch(vnode0, vnode1);
     assert.strictEqual(elm.firstChild.style.fontSize, "14px");
     patch(vnode1, vnode2);
@@ -70,9 +83,9 @@ describe("style", function () {
     if (!hasCssVariables) {
       this.skip();
     } else {
-      const vnode1 = h("div", { style: { "--myVar": 1 as any } as any });
-      const vnode2 = h("div", { style: { "--myVar": 2 as any } as any });
-      const vnode3 = h("div", { style: { "--myVar": 3 as any } as any });
+      const vnode1 = h("div", { style: { base: { "--myVar": 1 } } });
+      const vnode2 = h("div", { style: { base: { "--myVar": 2 } } });
+      const vnode3 = h("div", { style: { base: { "--myVar": 3 } } });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.getPropertyValue("--myVar"), "1");
       elm = patch(vnode1, vnode2).elm;
@@ -85,9 +98,9 @@ describe("style", function () {
     if (!hasCssVariables) {
       this.skip();
     } else {
-      const vnode1 = h("i", { style: { "--myVar": 1 as any } as any });
-      const vnode2 = h("i", { style: { "--myVar": "" } as any });
-      const vnode3 = h("i", { style: { "--myVar": 2 as any } as any });
+      const vnode1 = h("i", { style: { base: { "--myVar": 1 } } });
+      const vnode2 = h("i", { style: { base: { "--myVar": "" } } });
+      const vnode3 = h("i", { style: { base: { "--myVar": 2 } } });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.getPropertyValue("--myVar"), "1");
       patch(vnode1, vnode2);
@@ -100,9 +113,9 @@ describe("style", function () {
     if (!hasCssVariables) {
       this.skip();
     } else {
-      const vnode1 = h("div", [h("i", { style: { "--myVar": 1 as any } as any })]);
+      const vnode1 = h("div", [h("i", { style: { base: { "--myVar": 1 } } })]);
       const vnode2 = h("div", [h("i")]);
-      const vnode3 = h("div", [h("i", { style: { "--myVar": 2 as any } as any })]);
+      const vnode3 = h("div", [h("i", { style: { base: { "--myVar": 2 } } })]);
       patch(vnode0, vnode1);
       assert.strictEqual(elm.firstChild.style.getPropertyValue("--myVar"), "1");
       patch(vnode1, vnode2);
@@ -114,10 +127,10 @@ describe("style", function () {
   describe("delayed", function () {
     it("updates delayed styles in next frame", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
+        style: { base: { fontSize: "14px" }, delayed: { fontSize: "16px" } },
       });
       const vnode2 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "18px" } as any } as any,
+        style: { base: { fontSize: "14px" }, delayed: { fontSize: "18px" } },
       });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.fontSize, "14px");
@@ -137,10 +150,10 @@ describe("style", function () {
     });
     it("updates delayed styles in next frame when default styles also change", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
+        style: { base: { fontSize: "14px" }, delayed: { fontSize: "16px" } },
       });
       const vnode2 = h("i", {
-        style: { fontSize: "18px", delayed: { fontSize: "20px" } as any } as any,
+        style: { base: { fontSize: "18px" }, delayed: { fontSize: "20px" } },
       });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.fontSize, "14px");
@@ -160,10 +173,10 @@ describe("style", function () {
     });
     it("handles multiple delayed style changes before next frame", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
+        style: { base: { fontSize: "14px" }, delayed: { fontSize: "16px" } },
       });
       const vnode2 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "18px" } as any } as any,
+        style: { base: { fontSize: "14px" }, delayed: { fontSize: "18px" } },
       });
       elm = patch(vnode0, vnode1).elm;
       elm = patch(vnode1, vnode2).elm;
@@ -177,10 +190,10 @@ describe("style", function () {
     });
     it("handles delayed style change that gets removed before next frame", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
+        style: { base: { fontSize: "14px" }, delayed: { fontSize: "16px" } },
       });
       const vnode2 = h("i", {
-        style: { fontSize: "14px", delayed: {} as any } as any,
+        style: { base: { fontSize: "14px" }, delayed: {} },
       });
       elm = patch(vnode0, vnode1).elm;
       elm = patch(vnode1, vnode2).elm;
@@ -194,10 +207,10 @@ describe("style", function () {
     });
     it("applies base style immediately and reschedules delayed change", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
+        style: { base: { fontSize: "14px" }, delayed: { fontSize: "16px" } },
       });
       const vnode2 = h("i", {
-        style: { fontSize: "18px", delayed: { fontSize: "16px" } as any } as any,
+        style: { base: { fontSize: "18px" }, delayed: { fontSize: "16px" } },
       });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.fontSize, "14px");
@@ -217,10 +230,10 @@ describe("style", function () {
     });
     it("reverts a delayed style synchronously", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
+        style: { base: { fontSize: "14px" }, delayed: { fontSize: "16px" } },
       });
       const vnode2 = h("i", {
-        style: { fontSize: "14px", delayed: {} as any } as any,
+        style: { base: { fontSize: "14px" }, delayed: {} },
       });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.fontSize, "14px");
@@ -235,10 +248,10 @@ describe("style", function () {
     });
     it("removes a delayed style synchronously", function (done) {
       const vnode1 = h("i", {
-        style: { delayed: { fontSize: "16px" } as any },
+        style: { delayed: { fontSize: "16px" } },
       });
       const vnode2 = h("i", {
-        style: { delayed: {} as any },
+        style: { delayed: {} },
       });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.fontSize, "");
@@ -257,9 +270,11 @@ describe("style", function () {
       "button",
       {
         style: {
-          transition: "transform 0.1s",
-          remove: { transform: "translateY(100%)" } as any,
-        } as any,
+          base: {
+            transition: "transform 0.1s",
+          },
+          remove: { transform: "translateY(100%)" },
+        },
       },
       ["A button"]
     );

--- a/test/unit/style.ts
+++ b/test/unit/style.ts
@@ -192,7 +192,7 @@ describe("style", function () {
         });
       });
     });
-    it("applies synchronous style immediately and reschedules delayed change", function (done) {
+    it("applies base style immediately and reschedules delayed change", function (done) {
       const vnode1 = h("i", {
         style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
       });

--- a/test/unit/style.ts
+++ b/test/unit/style.ts
@@ -16,13 +16,13 @@ describe("style", function () {
     vnode0 = elm;
   });
   it("is being styled", function () {
-    elm = patch(vnode0, h("div", { style: { fontSize: "12px" } })).elm;
+    elm = patch(vnode0, h("div", { style: { fontSize: "12px" } as any })).elm;
     assert.strictEqual(elm.style.fontSize, "12px");
   });
   it("can be memoized", function () {
     const cachedStyles = { fontSize: "14px", display: "inline" };
-    const vnode1 = h("i", { style: cachedStyles });
-    const vnode2 = h("i", { style: cachedStyles });
+    const vnode1 = h("i", { style: cachedStyles } as any);
+    const vnode2 = h("i", { style: cachedStyles } as any);
     elm = patch(vnode0, vnode1).elm;
     assert.strictEqual(elm.style.fontSize, "14px");
     assert.strictEqual(elm.style.display, "inline");
@@ -31,9 +31,9 @@ describe("style", function () {
     assert.strictEqual(elm.style.display, "inline");
   });
   it("updates styles", function () {
-    const vnode1 = h("i", { style: { fontSize: "14px", display: "inline" } });
-    const vnode2 = h("i", { style: { fontSize: "12px", display: "block" } });
-    const vnode3 = h("i", { style: { fontSize: "10px", display: "block" } });
+    const vnode1 = h("i", { style: { fontSize: "14px", display: "inline" } as any });
+    const vnode2 = h("i", { style: { fontSize: "12px", display: "block" } as any });
+    const vnode3 = h("i", { style: { fontSize: "10px", display: "block" } as any });
     elm = patch(vnode0, vnode1).elm;
     assert.strictEqual(elm.style.fontSize, "14px");
     assert.strictEqual(elm.style.display, "inline");
@@ -45,9 +45,9 @@ describe("style", function () {
     assert.strictEqual(elm.style.display, "block");
   });
   it("explicialy removes styles", function () {
-    const vnode1 = h("i", { style: { fontSize: "14px" } });
-    const vnode2 = h("i", { style: { fontSize: "" } });
-    const vnode3 = h("i", { style: { fontSize: "10px" } });
+    const vnode1 = h("i", { style: { fontSize: "14px" } as any });
+    const vnode2 = h("i", { style: { fontSize: "" } as any });
+    const vnode3 = h("i", { style: { fontSize: "10px" } as any });
     elm = patch(vnode0, vnode1).elm;
     assert.strictEqual(elm.style.fontSize, "14px");
     patch(vnode1, vnode2);
@@ -56,9 +56,9 @@ describe("style", function () {
     assert.strictEqual(elm.style.fontSize, "10px");
   });
   it("implicially removes styles from element", function () {
-    const vnode1 = h("div", [h("i", { style: { fontSize: "14px" } })]);
+    const vnode1 = h("div", [h("i", { style: { fontSize: "14px" } as any })]);
     const vnode2 = h("div", [h("i")]);
-    const vnode3 = h("div", [h("i", { style: { fontSize: "10px" } })]);
+    const vnode3 = h("div", [h("i", { style: { fontSize: "10px" } as any })]);
     patch(vnode0, vnode1);
     assert.strictEqual(elm.firstChild.style.fontSize, "14px");
     patch(vnode1, vnode2);
@@ -70,9 +70,9 @@ describe("style", function () {
     if (!hasCssVariables) {
       this.skip();
     } else {
-      const vnode1 = h("div", { style: { "--myVar": 1 as any } });
-      const vnode2 = h("div", { style: { "--myVar": 2 as any } });
-      const vnode3 = h("div", { style: { "--myVar": 3 as any } });
+      const vnode1 = h("div", { style: { "--myVar": 1 as any } as any });
+      const vnode2 = h("div", { style: { "--myVar": 2 as any } as any });
+      const vnode3 = h("div", { style: { "--myVar": 3 as any } as any });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.getPropertyValue("--myVar"), "1");
       elm = patch(vnode1, vnode2).elm;
@@ -85,9 +85,9 @@ describe("style", function () {
     if (!hasCssVariables) {
       this.skip();
     } else {
-      const vnode1 = h("i", { style: { "--myVar": 1 as any } });
-      const vnode2 = h("i", { style: { "--myVar": "" } });
-      const vnode3 = h("i", { style: { "--myVar": 2 as any } });
+      const vnode1 = h("i", { style: { "--myVar": 1 as any } as any });
+      const vnode2 = h("i", { style: { "--myVar": "" } as any });
+      const vnode3 = h("i", { style: { "--myVar": 2 as any } as any });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.getPropertyValue("--myVar"), "1");
       patch(vnode1, vnode2);
@@ -100,9 +100,9 @@ describe("style", function () {
     if (!hasCssVariables) {
       this.skip();
     } else {
-      const vnode1 = h("div", [h("i", { style: { "--myVar": 1 as any } })]);
+      const vnode1 = h("div", [h("i", { style: { "--myVar": 1 as any } as any })]);
       const vnode2 = h("div", [h("i")]);
-      const vnode3 = h("div", [h("i", { style: { "--myVar": 2 as any } })]);
+      const vnode3 = h("div", [h("i", { style: { "--myVar": 2 as any } as any })]);
       patch(vnode0, vnode1);
       assert.strictEqual(elm.firstChild.style.getPropertyValue("--myVar"), "1");
       patch(vnode1, vnode2);
@@ -114,10 +114,10 @@ describe("style", function () {
   describe("delayed", function () {
     it("updates delayed styles in next frame", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
       });
       const vnode2 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "18px" } as any },
+        style: { fontSize: "14px", delayed: { fontSize: "18px" } as any } as any,
       });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.fontSize, "14px");
@@ -137,10 +137,10 @@ describe("style", function () {
     });
     it("updates delayed styles in next frame when default styles also change", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
       });
       const vnode2 = h("i", {
-        style: { fontSize: "18px", delayed: { fontSize: "20px" } as any },
+        style: { fontSize: "18px", delayed: { fontSize: "20px" } as any } as any,
       });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.fontSize, "14px");
@@ -160,10 +160,10 @@ describe("style", function () {
     });
     it("handles multiple delayed style changes before next frame", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
       });
       const vnode2 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "18px" } as any },
+        style: { fontSize: "14px", delayed: { fontSize: "18px" } as any } as any,
       });
       elm = patch(vnode0, vnode1).elm;
       elm = patch(vnode1, vnode2).elm;
@@ -177,10 +177,10 @@ describe("style", function () {
     });
     it("handles delayed style change that gets removed before next frame", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
       });
       const vnode2 = h("i", {
-        style: { fontSize: "14px", delayed: {} as any },
+        style: { fontSize: "14px", delayed: {} as any } as any,
       });
       elm = patch(vnode0, vnode1).elm;
       elm = patch(vnode1, vnode2).elm;
@@ -194,10 +194,10 @@ describe("style", function () {
     });
     it("applies base style immediately and reschedules delayed change", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
       });
       const vnode2 = h("i", {
-        style: { fontSize: "18px", delayed: { fontSize: "16px" } as any },
+        style: { fontSize: "18px", delayed: { fontSize: "16px" } as any } as any,
       });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.fontSize, "14px");
@@ -217,10 +217,10 @@ describe("style", function () {
     });
     it("reverts a delayed style synchronously", function (done) {
       const vnode1 = h("i", {
-        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any } as any,
       });
       const vnode2 = h("i", {
-        style: { fontSize: "14px", delayed: {} as any },
+        style: { fontSize: "14px", delayed: {} as any } as any,
       });
       elm = patch(vnode0, vnode1).elm;
       assert.strictEqual(elm.style.fontSize, "14px");
@@ -259,7 +259,7 @@ describe("style", function () {
         style: {
           transition: "transform 0.1s",
           remove: { transform: "translateY(100%)" } as any,
-        },
+        } as any,
       },
       ["A button"]
     );

--- a/test/unit/style.ts
+++ b/test/unit/style.ts
@@ -22,6 +22,13 @@ describe("style", function () {
     ).elm;
     assert.strictEqual(elm.style.fontSize, "12px");
   });
+  it("is being with legacy api where props on the root object", function () {
+    elm = patch(
+      vnode0,
+      h("div", { style: { fontSize: "12px" } as any })
+    ).elm;
+    assert.strictEqual(elm.style.fontSize, "12px");
+  });
   it("can be memoized", function () {
     const cachedStyles = { fontSize: "14px", display: "inline" };
     const vnode1 = h("i", { style: { base: cachedStyles } });

--- a/test/unit/style.ts
+++ b/test/unit/style.ts
@@ -111,25 +111,143 @@ describe("style", function () {
       assert.strictEqual(elm.firstChild.style.getPropertyValue("--myVar"), "2");
     }
   });
-  it("updates delayed styles in next frame", function (done) {
-    const vnode1 = h("i", {
-      style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
-    });
-    const vnode2 = h("i", {
-      style: { fontSize: "18px", delayed: { fontSize: "20px" } as any },
-    });
-    elm = patch(vnode0, vnode1).elm;
-    assert.strictEqual(elm.style.fontSize, "14px");
-    requestAnimationFrame(() => {
+  describe("delayed", function () {
+    it("updates delayed styles in next frame", function (done) {
+      const vnode1 = h("i", {
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+      });
+      const vnode2 = h("i", {
+        style: { fontSize: "14px", delayed: { fontSize: "18px" } as any },
+      });
+      elm = patch(vnode0, vnode1).elm;
+      assert.strictEqual(elm.style.fontSize, "14px");
       requestAnimationFrame(() => {
-        assert.strictEqual(elm.style.fontSize, "16px");
-        elm = patch(vnode1, vnode2).elm;
-        assert.strictEqual(elm.style.fontSize, "18px");
         requestAnimationFrame(() => {
+          assert.strictEqual(elm.style.fontSize, "16px");
+          elm = patch(vnode1, vnode2).elm;
+          assert.strictEqual(elm.style.fontSize, "16px");
           requestAnimationFrame(() => {
-            assert.strictEqual(elm.style.fontSize, "20px");
-            done();
+            requestAnimationFrame(() => {
+              assert.strictEqual(elm.style.fontSize, "18px");
+              done();
+            });
           });
+        });
+      });
+    });
+    it("updates delayed styles in next frame when default styles also change", function (done) {
+      const vnode1 = h("i", {
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+      });
+      const vnode2 = h("i", {
+        style: { fontSize: "18px", delayed: { fontSize: "20px" } as any },
+      });
+      elm = patch(vnode0, vnode1).elm;
+      assert.strictEqual(elm.style.fontSize, "14px");
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          assert.strictEqual(elm.style.fontSize, "16px");
+          elm = patch(vnode1, vnode2).elm;
+          assert.strictEqual(elm.style.fontSize, "18px");
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              assert.strictEqual(elm.style.fontSize, "20px");
+              done();
+            });
+          });
+        });
+      });
+    });
+    it("handles multiple delayed style changes before next frame", function (done) {
+      const vnode1 = h("i", {
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+      });
+      const vnode2 = h("i", {
+        style: { fontSize: "14px", delayed: { fontSize: "18px" } as any },
+      });
+      elm = patch(vnode0, vnode1).elm;
+      elm = patch(vnode1, vnode2).elm;
+      assert.strictEqual(elm.style.fontSize, "14px");
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          assert.strictEqual(elm.style.fontSize, "18px");
+          done();
+        });
+      });
+    });
+    it("handles delayed style change that gets removed before next frame", function (done) {
+      const vnode1 = h("i", {
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+      });
+      const vnode2 = h("i", {
+        style: { fontSize: "14px", delayed: {} as any },
+      });
+      elm = patch(vnode0, vnode1).elm;
+      elm = patch(vnode1, vnode2).elm;
+      assert.strictEqual(elm.style.fontSize, "14px");
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          assert.strictEqual(elm.style.fontSize, "14px");
+          done();
+        });
+      });
+    });
+    it("applies synchronous style immediately and reschedules delayed change", function (done) {
+      const vnode1 = h("i", {
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+      });
+      const vnode2 = h("i", {
+        style: { fontSize: "18px", delayed: { fontSize: "16px" } as any },
+      });
+      elm = patch(vnode0, vnode1).elm;
+      assert.strictEqual(elm.style.fontSize, "14px");
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          assert.strictEqual(elm.style.fontSize, "16px");
+          elm = patch(vnode1, vnode2).elm;
+          assert.strictEqual(elm.style.fontSize, "18px");
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              assert.strictEqual(elm.style.fontSize, "16px");
+              done();
+            });
+          });
+        });
+      });
+    });
+    it("reverts a delayed style synchronously", function (done) {
+      const vnode1 = h("i", {
+        style: { fontSize: "14px", delayed: { fontSize: "16px" } as any },
+      });
+      const vnode2 = h("i", {
+        style: { fontSize: "14px", delayed: {} as any },
+      });
+      elm = patch(vnode0, vnode1).elm;
+      assert.strictEqual(elm.style.fontSize, "14px");
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          assert.strictEqual(elm.style.fontSize, "16px");
+          elm = patch(vnode1, vnode2).elm;
+          assert.strictEqual(elm.style.fontSize, "14px");
+          done();
+        });
+      });
+    });
+    it("removes a delayed style synchronously", function (done) {
+      const vnode1 = h("i", {
+        style: { delayed: { fontSize: "16px" } as any },
+      });
+      const vnode2 = h("i", {
+        style: { delayed: {} as any },
+      });
+      elm = patch(vnode0, vnode1).elm;
+      assert.strictEqual(elm.style.fontSize, "");
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          assert.strictEqual(elm.style.fontSize, "16px");
+          elm = patch(vnode1, vnode2).elm;
+          assert.strictEqual(elm.style.fontSize, "");
+          done();
         });
       });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "strictFunctionTypes": false,
     "moduleResolution": "node",
-    "target": "es6",
+    "target": "es5",
     "outDir": "build"
   },
   "include": ["./src/index.ts"]


### PR DESCRIPTION
**This builds on https://github.com/snabbdom/snabbdom/pull/1028 so please check that first**

This updates the api for the `style` module to have the base props go on a `base` property and updates the types to match that.

The properties are still supported on the root, but the types will complain.

The reason for this is that it's not possible (afaik) to get types that work with the current style as you can only say that the root object has all keys as `string`, and therefore it's not possible to support `delayed` and `remove` as objects themselves. Also with the current approach if there was a new style in the future called `delayed` or `remove` (which is unlikely), there'd be a collision. You'll see now in the test file `any` is not needed

I'm not sure if this should be considered a major change or not. For javascript, it's not breaking as the old way still works fine, but if you use typescript, it will start complaining 🤔 