### PR TITLE
chore(test): use actions/checkout@v3, replacing v2

### DIFF
--- a/.github/workflows/steps.yml
+++ b/.github/workflows/steps.yml
@@ -9,12 +9,9 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
       - run: npm ci
-
       - run: npm test
         env:
           BROWSER_STACK_USERNAME: ${{ secrets.BROWSER_STACK_USERNAME }}


### PR DESCRIPTION
Specify actions/checkout@v3 for ci tests and remove empty newlines. [V3 is the newer version][0] using node16 runtime,
```diff
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
```

[0]: https://github.com/actions/checkout/compare/v2.4.2...v3.0.2#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R18