### PR TITLE
chore(test): use default concurrency 1, so local unit tests do not hang

### DIFF
--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -14,7 +14,7 @@ const sharedCapabilities = {
 
 export default {
   concurrentBrowsers: 2,
-  concurrency: ci ? 2 : undefined,
+  concurrency: ci ? 2 : 1,
   browsers: !ci
     ? undefined
     : Object.values(browsers).map((cap) =>


### PR DESCRIPTION
closes https://github.com/snabbdom/snabbdom/issues/1059