### PR TITLE
fix: patching namespaced attributes (#1049)

### DIFF
--- a/src/modules/attributes.ts
+++ b/src/modules/attributes.ts
@@ -4,9 +4,11 @@ import { Module } from "./module";
 export type Attrs = Record<string, string | number | boolean>;
 
 const xlinkNS = "http://www.w3.org/1999/xlink";
+const xmlnsNS = "http://www.w3.org/2000/xmlns/";
 const xmlNS = "http://www.w3.org/XML/1998/namespace";
 const colonChar = 58;
 const xChar = 120;
+const mChar = 109;
 
 function updateAttrs(oldVnode: VNode, vnode: VNode): void {
   let key: string;
@@ -35,8 +37,10 @@ function updateAttrs(oldVnode: VNode, vnode: VNode): void {
           // Assume xml namespace
           elm.setAttributeNS(xmlNS, key, cur as any);
         } else if (key.charCodeAt(5) === colonChar) {
-          // Assume xlink namespace
-          elm.setAttributeNS(xlinkNS, key, cur as any);
+          // Assume 'xmlns' or 'xlink' namespace
+          key.charCodeAt(1) === mChar
+            ? elm.setAttributeNS(xmlnsNS, key, cur as any)
+            : elm.setAttributeNS(xlinkNS, key, cur as any);
         } else {
           elm.setAttribute(key, cur as any);
         }

--- a/test/unit/attributes.ts
+++ b/test/unit/attributes.ts
@@ -64,6 +64,26 @@ describe("attributes", function () {
     assert.strictEqual(elm.className, "myClass");
     assert.strictEqual(elm.textContent, "Hello");
   });
+  it("should apply legacy namespace attributes, xmlns", function () {
+    const elmNamespaceQualifiedName = "xmlns:xlink";
+    const elmNamespaceValue = "http://www.w3.org/1999/xlink";
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const vnodeSVG = h("svg", {
+      attrs: { [elmNamespaceQualifiedName]: elmNamespaceValue },
+    });
+
+    elm = patch(svg, vnodeSVG).elm;
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNS
+    // > Namespaces are only supported in XML documents. HTML documents have to
+    // > use getAttribute() instead.
+    //
+    // MDN advise getAttribute over getAttributeNS, as the latter returns `null`
+    // and namespaces are a legacy feature, no longer supported
+    assert.strictEqual(
+      elm.getAttribute(elmNamespaceQualifiedName),
+      elmNamespaceValue,
+    );
+  });
   describe("boolean attribute", function () {
     it("is present and empty string if the value is truthy", function () {
       const vnode1 = h("div", {


### PR DESCRIPTION
closes https://github.com/snabbdom/snabbdom/issues/1049

Node's runtime appeared to be unfarily optimising part the benchmark test for the original charCodeAt implementation. The final benchmark was updated to more closely resemble the actual behaviour of snabbdom. The final benchmark test and results are attached.

<details>
  <summary>benchmark</summary>

```javascript
// $ node ~/software/performance.js
const common = require('./node/benchmark/common.js');

const bench = common.createBenchmark(main, {
  n: [1000000000],
  type: [
    'charCodeAt',
    'charCodeAtV2'
  ],
  string: ['svg:test', 'xmlns:test', 'nonamespace']
});

function main(conf) {
  const string = conf.string
  const type = conf.type

  const set = (res, o = {}) => {
    o[res] = res
    return o
  }

  
  if (type === 'charCodeAt') {
    const colonChar = 58;

    bench.start();
    for (let i = conf.n, res; i--;) {
      if (string.charCodeAt(3) === colonChar)
        res = set('xml')
      else if (string.charCodeAt(5) === colonChar)
        res = set('xlink')
      else
        res = set('default')
    }
    bench.end(conf.n);
  }
  
  if (type === 'charCodeAtV2') {
    const colonChar = 58;
    const sChar = 115
    const mChar = 109
    
    bench.start();
    for (let i = conf.n, index, res; i--;) {
      if (string.charCodeAt(3) === colonChar)
        res = string.charCodeAt(0) === sChar ? set('svg') : set('xml')
      else if (string.charCodeAt(5) === colonChar)
        res = string.charCodeAt(1) === mChar ? set('xmlns') : set('xlink')
      else
        res = set('default')
    }
    bench.end(conf.n);
  }
}
```

</details>

```bash
$ node performance.js
 string="svg:test" type="charCodeAt"      n=1000000000: 361,036,563.2385391
 string="xmlns:test" type="charCodeAt"    n=1000000000: 275,365,679.2197518
 string="nonamespace" type="charCodeAt"   n=1000000000: 272,258,333.43921006
 string="svg:test" type="charCodeAtV2"    n=1000000000: 252,936,939.33049515
 string="xmlns:test" type="charCodeAtV2"  n=1000000000: 191,371,874.75000075
 string="nonamespace" type="charCodeAtV2" n=1000000000: 268,935,014.03115726
```

Feel free to give advice or criticism