### PR TITLE
fix: patch should apply textNodes (#972)

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -160,6 +160,9 @@ export function init(
         vnode.text = "";
       }
       vnode.elm = api.createComment(vnode.text!);
+    } else if (sel === "") {
+      // textNode has no selector
+      vnode.elm = api.createTextNode(vnode.text!);
     } else if (sel !== undefined) {
       // Parse selector
       const hashIdx = sel.indexOf("#");
@@ -178,6 +181,13 @@ export function init(
       if (dotIdx > 0)
         elm.setAttribute("class", sel.slice(dot + 1).replace(/\./g, " "));
       for (i = 0; i < cbs.create.length; ++i) cbs.create[i](emptyNode, vnode);
+      if (
+        is.primitive(vnode.text) &&
+        (!is.array(children) || children.length === 0)
+      ) {
+        // allow h1 and similar nodes to be created w/ text and empty child list
+        api.appendChild(elm, api.createTextNode(vnode.text));
+      }
       if (is.array(children)) {
         for (i = 0; i < children.length; ++i) {
           const ch = children[i];
@@ -185,8 +195,6 @@ export function init(
             api.appendChild(elm, createElm(ch as VNode, insertedVnodeQueue));
           }
         }
-      } else if (is.primitive(vnode.text)) {
-        api.appendChild(elm, api.createTextNode(vnode.text));
       }
       const hook = vnode.data!.hook;
       if (isDef(hook)) {

--- a/test/unit/core.ts
+++ b/test/unit/core.ts
@@ -497,6 +497,19 @@ describe("snabbdom", function () {
         assert.strictEqual(elm.childNodes[0].childNodes[0].tagName, "SPAN");
         assert.strictEqual(elm.childNodes[0].childNodes[0].textContent, "Hi");
       });
+      it("patching textNodes, adding and removing", function () {
+        const prevElm = document.createElement("div");
+        const vnodeText1 = vnode("", {}, [], "Test Text 1", null);
+        const vnodeText2 = vnode("", {}, [], "Test Text 2", null);
+        const vnodeH1 = vnode("h1", {}, [], "Test Text h1", null);
+
+        elm = patch(toVNode(prevElm), vnodeText1).elm;
+        assert.strictEqual(elm.nodeValue, "Test Text 1");
+        elm = patch(toVNode(elm), vnodeText2).elm;
+        assert.strictEqual(elm.nodeValue, "Test Text 2");
+        elm = patch(toVNode(elm), vnodeH1).elm;
+        assert.strictEqual(elm.textContent, "Test Text h1");
+      });
       it("can remove some children of the root element", function () {
         const h2 = document.createElement("h2");
         h2.textContent = "Hello";


### PR DESCRIPTION
closes https://github.com/snabbdom/snabbdom/issues/972
closes https://github.com/snabbdom/snabbdom/issues/971

Feel free to leave criticism. Changes are not smoke-tested, however all unit-tests are passing.

Some parts of createElm were rearranged to support these scenarious,
 * `vnode("", {}, [], "Test Text 1", null)` if there is no selector, a textNode is created as one of the first conditions
 * `vnode("h1", {}, [], "Test Text h1", null)` if there is a selector, a primitive vnode text AND an empty child list, a textNode is childed to the element