### PR TITLE
chore(tools): use npm files directive for smaller publish size

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "engines": {
     "node": ">=8.3.0"
   },
+  "files": [
+    "build"
+  ],
   "type": "module",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
`npm publish --dry-run` before this change
```bash
npm notice === Tarball Details === 
npm notice name:          snabbdom                                
npm notice version:       3.5.1                                   
npm notice filename:      snabbdom-3.5.1.tgz                      
npm notice package size:  89.8 kB                                 
npm notice unpacked size: 387.6 kB                                
npm notice shasum:        e1e33224b1397bc6633a3cff1c8af718da612c01
npm notice integrity:     sha512-FDUepV7ay0KHD[...]W2N0zF8lSXffg==
npm notice total files:   116
```

`npm publish --dry-run` after this change
```bash
npm notice === Tarball Details === 
npm notice name:          snabbdom                                
npm notice version:       3.5.1                                   
npm notice filename:      snabbdom-3.5.1.tgz                      
npm notice package size:  32.8 kB                                 
npm notice unpacked size: 125.3 kB                                
npm notice shasum:        bf8c7416b440f50635dcd435eb8befccfae4344f
npm notice integrity:     sha512-wxR/BsS+6FphQ[...]+ve0bRMPqh5oQ==
npm notice total files:   57
```

Two more changes that would be great for reducing the final package size,
 1. **use npm's script.prepublishOnly** directive to remove un-needed parts of package.json. For example, `"prepublishOnly": "npm pkg delete scripts devDependencies commithelper release-it"` would reduce package.json from ~2.7kB to ~1.3kB,
 2. **reduce the size of the main README** the current snabbdom README is ~31.9kB. For comparison, the [react-dom](https://www.npmjs.com/package/react-dom?activeTab=code) README size is ~1.1kB