### PR TITLE
chore(docs): reference readme-title image from imgur

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img alt="Snabbdom" src="readme-title.svg" width="356px">
+<img alt="Snabbdom" src="https://raw.githubusercontent.com/snabbdom/snabbdom/master/readme-title.svg" width="356px">
 
 A virtual DOM library with a focus on simplicity, modularity, powerful features
 and performance.


### PR DESCRIPTION
```diff
diff --git a/README.md b/README.md
index 1d72a15..92038f9 100644
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img alt="Snabbdom" src="readme-title.svg" width="356px">
+<img alt="Snabbdom" src="https://i.imgur.com/4Bq0tyi.png" width="356px">
 
 A virtual DOM library with a focus on simplicity, modularity, powerful features
 and performance.
```

This PR updates the image reference in the README from a relative image path to an imgur image url, and the reason for the change is discussed at the [bottom of this PR](https://github.com/snabbdom/snabbdom/pull/1063#issuecomment-1781595164)

imgur does not support svg. To preserve as much fidelity as possible, the image was imported to inkscape, scaled down to the README's 356px and then exported to PNG