### PR TITLE
chore(test): use actions/checkout@v4, replacing v3

### DIFF
--- a/.github/workflows/steps.yml
+++ b/.github/workflows/steps.yml
@@ -10,7 +10,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npm ci
       - run: npm test
         env:


### PR DESCRIPTION
https://github.com/actions/checkout/releases/tag/v4.0.0

The previous PR should have updated this to v4 rather than v3