### PR TITLE
fix: img src attribute patching (#958)

### DIFF
--- a/src/tovnode.ts
+++ b/src/tovnode.ts
@@ -24,7 +24,12 @@ export function toVNode(node: Node, domApi?: DOMAPI): VNode {
       if (name.startsWith("data-")) {
         dataset[name.slice(5)] = elmAttrs[i].nodeValue || "";
       } else if (name !== "id" && name !== "class") {
-        attrs[name] = elmAttrs[i].nodeValue;
+        if (name === "src") {
+          data.props = data.props || {};
+          data.props[name] = elmAttrs[i].nodeValue;
+        } else {
+          attrs[name] = elmAttrs[i].nodeValue;
+        }
       }
     }
     for (i = 0, n = elmChildren.length; i < n; i++) {

--- a/test/unit/core.ts
+++ b/test/unit/core.ts
@@ -449,6 +449,18 @@ describe("snabbdom", function () {
       }
     });
     describe("using toVNode()", function () {
+      it("can patch the src attribute of an image elment", function () {
+        const prevElm = document.createElement("img");
+        const newElm = document.createElement("img");
+        prevElm.src = "http://other/";
+        newElm.src = "http://localhost/";
+        const vnode1 = toVNode(prevElm);
+        const vnode2 = toVNode(newElm);
+        assert.strictEqual(vnode2.data.props.src, "http://localhost/");
+        patch(vnode0, vnode1);
+        elm = patch(vnode1, vnode2).elm;
+        assert.strictEqual(elm.src, "http://localhost/");
+      });
       it("can remove previous children of the root element", function () {
         const h2 = document.createElement("h2");
         h2.textContent = "Hello";


### PR DESCRIPTION
closes https://github.com/snabbdom/snabbdom/issues/958

**possibly there is no issue** and this PR should be closed, see comment https://github.com/snabbdom/snabbdom/pull/1066#issuecomment-1804737446 Essentially, src attribute is patched correctly when the patch function is composed around the attributes module/plugin