### PR TITLE
chore(tools): add lint job to ci pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: lint
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: npm install
+    # - run: npm run format-check
+    - run: npm run lint

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build": "tsc",
     "examples": "serve .",
     "format": "prettier --write .",
+    "format-check": "prettier --check .",
     "prepare": "husky install",
     "lint": "eslint --ext .ts,.tsx,.js --ignore-path .gitignore .",
     "unit": "web-test-runner \"test/unit/*.{ts,tsx}\" --node-resolve --coverage",


### PR DESCRIPTION
Later, prettier format-check can be enabled to require all files pass lint and prettier format-check at the ci pipeline for each PR
```diff
diff --git a/.github/workflows/lint.yml b/.github/workflows/lint.yml
index 5e0148e..1b99b44 100644
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: npm install
-    # - run: npm run format-check
+    - run: npm run format-check
     - run: npm run lint
```