### PR TITLE
chore(tools): added github package publishing job, runs when release is created

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: npm package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com/
+      - name: Insert repository owner as scope into package name
+        run: |
+          node <<EOF
+          const fs = require('fs').promises;
+          fs.readFile('package.json', 'utf8').then((data) => JSON.parse(data)).then((json) => {
+            json.name = '@$(echo "$GITHUB_REPOSITORY" | sed 's/\/.\+//')/' + json.name;
+            console.info('Package name changed to %s', json.name);
+            return fs.writeFile('package.json', JSON.stringify(json), 'utf8');
+          }).catch(error => {
+            console.error(error);
+            process.exit(1);
+          });
+          EOF
+      - run: npm install
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This job publishes snabbdom to github's npm package repository and it will only run when a release is created. Github's package repository requires packages to be "scoped". Un-scoped package names like "snabbdom" need to have a scope added to them, so this part applies a scope to the name before publishing, so the published name becomes "@snabbdom/snabbdom"
```javascript
const fs = require('fs').promises;
fs.readFile('package.json', 'utf8').then((data) => JSON.parse(data)).then((json) => {
  json.name = '@$(echo "$GITHUB_REPOSITORY" | sed 's/\/.\+//')/' + json.name;
  console.info('Package name changed to %s', json.name);
  return fs.writeFile('package.json', JSON.stringify(json), 'utf8');
}).catch(error => {
  console.error(error);
  process.exit(1);
});
```

An example package published to github's package repository is https://github.com/iambumblehead/esmock/pkgs/npm/esmock

Mainly, this adds some small visual "bling" to the side of snabbdom's main github page https://github.com/snabbdom/snabbdom because when the package is published to github, a descriptive little box linking to the package will appear there at the side, for example see the little box at the side of this page https://github.com/iambumblehead/esmock

related link https://docs.github.com/en/packages/quickstart