### PR TITLE
chore(tools): remove devdependency cross-env; un-maintained, not used ~86kB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@web/test-runner-browserstack": "^0.6.2",
         "commithelper": "^1.2.0",
         "conventional-changelog-angular": "^7.0.0",
-        "cross-env": "7.0.3",
         "eslint": "8.52.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "2.29.0",
@@ -4471,24 +4470,6 @@
       },
       "engines": {
         "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
       }
     },
     "node_modules/cross-fetch": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@web/test-runner-browserstack": "^0.6.2",
     "commithelper": "^1.2.0",
     "conventional-changelog-angular": "^7.0.0",
-    "cross-env": "7.0.3",
     "eslint": "8.52.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "2.29.0",


### PR DESCRIPTION
This PR removes the cross-env devDependency, which is un-maintained. Snabbdom sources do not appear to use cross-env anywhere,
 * https://www.npmjs.com/package/cross-env
 * https://packagephobia.com/result?p=cross-env