### PR TITLE
fix: detect window.requestAnimationFrame function before calling

### DIFF
--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -8,9 +8,10 @@ export type VNodeStyle = Record<string, string> & {
 
 // Binding `requestAnimationFrame` like this fixes a bug in IE/Edge. See #360 and #409.
 const raf =
-  (typeof window !== "undefined" &&
-    window.requestAnimationFrame.bind(window)) ||
-  setTimeout;
+  typeof window?.requestAnimationFrame === "function"
+    ? window.requestAnimationFrame.bind(window)
+    : setTimeout;
+
 const nextFrame = function (fn: any) {
   raf(function () {
     raf(fn);


### PR DESCRIPTION
essentially, this is the same as https://github.com/snabbdom/snabbdom/pull/885