### PR TITLE
fix: correct minimum node version to one that supports modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/snabbdom/snabbdom/issues"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.17.0"
   },
   "files": [
     "build"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/snabbdom/snabbdom/issues"
   },
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=12.0.0"
   },
   "files": [
     "build"


### PR DESCRIPTION
Currently our `package.json` says minimum node engine version is `8`, but we have `"type": "module"` in our `package.json` and that requires node v12+ as per https://nodejs.org/dist/latest-v20.x/docs/api/esm.html#modules-ecmascript-modules

<img width="783" alt="Screenshot 2023-11-30 at 9 42 15 AM" src="https://github.com/snabbdom/snabbdom/assets/718067/f2443962-c1dc-476e-881a-e2fbbc22a5ca">
