### PR TITLE
Enhance JSX and VNode types

### DIFF
--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -106,11 +106,11 @@ export namespace jsx {
   /*
   IfEquals/WritableKeys: https://stackoverflow.com/questions/52443276/how-to-exclude-getter-only-properties-from-type-in-typescript/52473108#52473108
   */
-  export type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X
+  export type IfEquals<X, Y, Output> = (<T>() => T extends X
     ? 1
     : 2) extends <T>() => T extends Y ? 1 : 2
-    ? A
-    : B
+    ? Output
+    : never
 
   export type WritableKeys<T> = {
     [P in keyof T]-?: IfEquals<

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -121,7 +121,7 @@ export namespace jsx {
   }[keyof T]
 
   export type ElementProperties<T> = {
-    [Property in WritableKeys<T> as T[Property] extends string | number ? Property : never]?: T[Property]
+    [Property in WritableKeys<T> as T[Property] extends string | number | null | undefined ? Property : never]?: T[Property]
   }
 
   export type VNodeProps<T> = ElementProperties<T> & Props

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace, import/export */
 import { Key, vnode, VNode, VNodeData } from "./vnode";
 import { h, ArrayOrElement } from "./h";
+import { Props } from "./modules/props";
 
 // for conditional rendering we support boolean child element e.g cond && <tag />
 export type JsxVNodeChild =
@@ -101,7 +102,35 @@ export function jsx(
 // See https://www.typescriptlang.org/docs/handbook/jsx.html#type-checking
 export namespace jsx {
   export type Element = VNode;
-  export interface IntrinsicElements {
+
+  /*
+  IfEquals/WritableKeys: https://stackoverflow.com/questions/52443276/how-to-exclude-getter-only-properties-from-type-in-typescript/52473108#52473108
+  */
+  export type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X
+    ? 1
+    : 2) extends <T>() => T extends Y ? 1 : 2
+    ? A
+    : B
+
+  export type WritableKeys<T> = {
+    [P in keyof T]-?: IfEquals<
+      { [Q in P]: T[P] },
+      { -readonly [Q in P]: T[P] },
+      P
+    >
+  }[keyof T]
+
+  export type ElementProperties<T> = {
+    [Property in WritableKeys<T> as T[Property] extends string | number ? Property : never]?: T[Property]
+  }
+
+  export type VNodeProps<T> = ElementProperties<T> & Props
+
+  export type HtmlElements = {
+    [Property in keyof HTMLElementTagNameMap]: VNodeData<VNodeProps<HTMLElementTagNameMap[Property]>>
+  }
+
+  export interface IntrinsicElements extends HtmlElements {
     [elemName: string]: VNodeData;
   }
 }

--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -1,9 +1,7 @@
 import { VNode, VNodeData } from "../vnode";
 import { Module } from "./module";
 
-export type ElementStyle = {
-  [Property in keyof ElementCSSInlineStyle]?: ElementCSSInlineStyle[Property]
-}
+export type ElementStyle = Partial<CSSStyleDeclaration>
 
 export type VNodeStyle = ElementStyle & Record<string, string> & {
   delayed?: ElementStyle & Record<string, string>;

--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -1,9 +1,13 @@
 import { VNode, VNodeData } from "../vnode";
 import { Module } from "./module";
 
-export type VNodeStyle = Record<string, string> & {
-  delayed?: Record<string, string>;
-  remove?: Record<string, string>;
+export type ElementStyle = {
+  [Property in keyof ElementCSSInlineStyle]?: ElementCSSInlineStyle[Property]
+}
+
+export type VNodeStyle = ElementStyle & Record<string, string> & {
+  delayed?: ElementStyle & Record<string, string>;
+  remove?: ElementStyle & Record<string, string>;
 };
 
 // Binding `requestAnimationFrame` like this fixes a bug in IE/Edge. See #360 and #409.

--- a/src/vnode.ts
+++ b/src/vnode.ts
@@ -18,8 +18,8 @@ export interface VNode {
   key: Key | undefined;
 }
 
-export interface VNodeData {
-  props?: Props;
+export interface VNodeData<VNodeProps = Props> {
+  props?: VNodeProps;
   attrs?: Attrs;
   class?: Classes;
   style?: VNodeStyle;


### PR DESCRIPTION
- Use lib.dom's `HTMLTagNameMap` for HTML element property names in JSX
- Use lib.dom's `ElementCSSInlineStyle` for style property names in all VNodes

The meta-typing for HTML element property names could also be applied to `h` overloads as well and more VNode situations in general (`HTMLTagNameMap` exists for mapping overloads to among other things `document.createElement(elementName: string)`) but I didn't already have a working equivalent on hand, I just had the JSX specific types, so that isn't included in this PR.

This was JSX meta-typing that I discovered/built for [Butterfloat](https://worldmaker.net/butterfloat/), but having used Snabbdom in the past and may use Snabbdom in the future I thought would be useful to share the meta-programming wealth for better auto-complete in more JSX environments.