### PR TITLE
Handle falsy values correctly in the dataset and style modules

### DIFF
--- a/src/modules/dataset.ts
+++ b/src/modules/dataset.ts
@@ -18,7 +18,7 @@ function updateDataset(oldVnode: VNode, vnode: VNode): void {
   const d = elm.dataset;
 
   for (key in oldDataset) {
-    if (!dataset[key]) {
+    if (!(key in dataset)) {
       if (d) {
         if (key in d) {
           delete d[key];

--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -1,12 +1,13 @@
 import { VNode, VNodeData } from "../vnode";
 import { Module } from "./module";
 
-export type ElementStyle = Partial<CSSStyleDeclaration>
+export type ElementStyle = Partial<CSSStyleDeclaration>;
 
-export type VNodeStyle = ElementStyle & Record<string, string> & {
-  delayed?: ElementStyle & Record<string, string>;
-  remove?: ElementStyle & Record<string, string>;
-};
+export type VNodeStyle = ElementStyle &
+  Record<string, string> & {
+    delayed?: ElementStyle & Record<string, string>;
+    remove?: ElementStyle & Record<string, string>;
+  };
 
 // Binding `requestAnimationFrame` like this fixes a bug in IE/Edge. See #360 and #409.
 const raf =
@@ -40,7 +41,7 @@ function updateStyle(oldVnode: VNode, vnode: VNode): void {
   const oldHasDel = "delayed" in oldStyle;
 
   for (name in oldStyle) {
-    if (!style[name]) {
+    if (!(name in style)) {
       if (name[0] === "-" && name[1] === "-") {
         (elm as any).style.removeProperty(name);
       } else {

--- a/test/unit/dataset.ts
+++ b/test/unit/dataset.ts
@@ -40,6 +40,14 @@ describe("dataset", function () {
     assert.strictEqual(elm.dataset.baz, "baz");
     assert.strictEqual(elm.dataset.foo, undefined);
   });
+  it("handles falsy values", function () {
+    const vnode1 = h("i", { dataset: { foo: "" } });
+    const vnode2 = h("i", { dataset: { foo: "" } });
+    elm = patch(vnode0, vnode1).elm;
+    assert.strictEqual(elm.dataset.foo, "");
+    elm = patch(vnode1, vnode2).elm;
+    assert.strictEqual(elm.dataset.foo, "");
+  });
   it("can be memoized", function () {
     const cachedDataset = { foo: "foo", bar: "bar" };
     const vnode1 = h("i", { dataset: cachedDataset });

--- a/test/unit/style.ts
+++ b/test/unit/style.ts
@@ -55,6 +55,14 @@ describe("style", function () {
     patch(vnode2, vnode3);
     assert.strictEqual(elm.style.fontSize, "10px");
   });
+  it("handles falsy values", function () {
+    const vnode1 = h("i", { style: { flexShrink: 0 as any } });
+    const vnode2 = h("i", { style: { flexShrink: 0 as any } });
+    elm = patch(vnode0, vnode1).elm;
+    assert.strictEqual(elm.style.flexShrink, "0");
+    patch(vnode1, vnode2);
+    assert.strictEqual(elm.style.flexShrink, "0");
+  });
   it("implicially removes styles from element", function () {
     const vnode1 = h("div", [h("i", { style: { fontSize: "14px" } })]);
     const vnode2 = h("div", [h("i")]);


### PR DESCRIPTION
This PR fixes an issue where falsy values such as `0` or `""` where accidentally being removed by the dataset and styles module during diffing.

ISSUES CLOSED: #303, #1093