### PR TITLE
chore(tools): add build job to publish spec

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,18 @@ on:
     types: [created]
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm run build
   publish-gpr:
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://npm.pkg.github.com/


### PR DESCRIPTION
this PR adds a build job to the publish spec, when the publish spec was used a few days ago it failed because the spec includes "needs: build" and because no "build" job was defined. https://github.com/snabbdom/snabbdom/actions/runs/7593114398

"build" would be used to transpile or generate any resources that should be included in the published package.