### PR TITLE
Add `.js` extensions to the import specifiers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,7 +53,6 @@
     {
       "files": ["examples/**/*.js"],
       "rules": {
-        "import/no-unresolved": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off"
       }
     },
@@ -72,15 +71,13 @@
     {
       "files": ["README*md/*.tsx"],
       "rules": {
-        "@typescript-eslint/no-unused-vars": "off",
-        "import/no-unresolved": "off"
+        "@typescript-eslint/no-unused-vars": "off"
       }
     },
     {
       "files": ["CHANGELOG.md/*"],
       "rules": {
         "@typescript-eslint/no-unused-vars": "off",
-        "import/no-unresolved": "off",
         "node/no-missing-import": "off"
       }
     }
@@ -89,6 +86,7 @@
     "max-statements-per-line": "error",
     "no-var": "error",
     "import/newline-after-import": "error",
-    "import/no-default-export": "error"
+    "import/no-default-export": "error",
+    "import/no-unresolved": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "prettier": "^3.0.3",
         "release-it": "^16.2.1",
         "serve": "^14.2.1",
-        "ts-add-js-extension": "^1.6.0",
         "typescript": "5.2.2"
       },
       "engines": {
@@ -12705,18 +12704,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/ts-add-js-extension": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ts-add-js-extension/-/ts-add-js-extension-1.6.0.tgz",
-      "integrity": "sha512-vJSCfL0YEn0tPxJKSOgMEjxPoKnqLaW+stSLEtpY974/GkgEVukc0O7Q4ryAGbvEzP1WYVW/w563TO3uvFFbqw==",
-      "dev": true,
-      "dependencies": {
-        "typescript": "^5.2.2"
-      },
-      "bin": {
-        "ts-add-js-extension": "build/cjs/bin.js"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "prettier": "^3.0.3",
     "release-it": "^16.2.1",
     "serve": "^14.2.1",
-    "ts-add-js-extension": "^1.6.0",
     "typescript": "5.2.2"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "types": "build/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc && ts-add-js-extension --dir=build",
+    "build": "tsc",
     "examples": "serve .",
     "format": "prettier --write .",
     "format-check": "prettier --check .",

--- a/src/h.ts
+++ b/src/h.ts
@@ -1,5 +1,5 @@
-import { vnode, VNode, VNodeData } from "./vnode";
-import * as is from "./is";
+import { vnode, VNode, VNodeData } from "./vnode.js";
+import * as is from "./is.js";
 
 export type VNodes = VNode[];
 export type VNodeChildElement =

--- a/src/helpers/attachto.ts
+++ b/src/helpers/attachto.ts
@@ -1,4 +1,4 @@
-import { VNode, VNodeData } from "../vnode";
+import { VNode, VNodeData } from "../vnode.js";
 
 export interface AttachData {
   [key: string]: any;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,4 @@
-import { VNode } from "./vnode";
+import { VNode } from "./vnode.js";
 
 export type PreHook = () => any;
 export type InitHook = (vNode: VNode) => any;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,46 +1,50 @@
 // core
-export { htmlDomApi } from "./htmldomapi";
-export { init } from "./init";
-export { thunk } from "./thunk";
-export { vnode } from "./vnode";
+export { htmlDomApi } from "./htmldomapi.js";
+export { init } from "./init.js";
+export { thunk } from "./thunk.js";
+export { vnode } from "./vnode.js";
 
-export type { DOMAPI } from "./htmldomapi";
-export type { Options } from "./init";
-export type { ThunkData, Thunk, ThunkFn } from "./thunk";
-export type { Key, VNode, VNodeData } from "./vnode";
+export type { DOMAPI } from "./htmldomapi.js";
+export type { Options } from "./init.js";
+export type { ThunkData, Thunk, ThunkFn } from "./thunk.js";
+export type { Key, VNode, VNodeData } from "./vnode.js";
 
 // helpers
-export { attachTo } from "./helpers/attachto";
-export { array, primitive } from "./is";
-export { toVNode } from "./tovnode";
-export { h, fragment } from "./h";
+export { attachTo } from "./helpers/attachto.js";
+export { array, primitive } from "./is.js";
+export { toVNode } from "./tovnode.js";
+export { h, fragment } from "./h.js";
 
-export type { AttachData } from "./helpers/attachto";
+export type { AttachData } from "./helpers/attachto.js";
 export type {
   VNodes,
   VNodeChildElement,
   ArrayOrElement,
   VNodeChildren
-} from "./h";
+} from "./h.js";
 
 // types
-export * from "./hooks";
-export type { Module } from "./modules/module";
+export * from "./hooks.js";
+export type { Module } from "./modules/module.js";
 
 // modules
-export { attributesModule } from "./modules/attributes";
-export { classModule } from "./modules/class";
-export { datasetModule } from "./modules/dataset";
-export { eventListenersModule } from "./modules/eventlisteners";
-export { propsModule } from "./modules/props";
-export { styleModule } from "./modules/style";
-export type { Attrs } from "./modules/attributes";
-export type { Classes } from "./modules/class";
-export type { Dataset } from "./modules/dataset";
-export type { On } from "./modules/eventlisteners";
-export type { Props } from "./modules/props";
-export type { VNodeStyle } from "./modules/style";
+export { attributesModule } from "./modules/attributes.js";
+export { classModule } from "./modules/class.js";
+export { datasetModule } from "./modules/dataset.js";
+export { eventListenersModule } from "./modules/eventlisteners.js";
+export { propsModule } from "./modules/props.js";
+export { styleModule } from "./modules/style.js";
+export type { Attrs } from "./modules/attributes.js";
+export type { Classes } from "./modules/class.js";
+export type { Dataset } from "./modules/dataset.js";
+export type { On } from "./modules/eventlisteners.js";
+export type { Props } from "./modules/props.js";
+export type { VNodeStyle } from "./modules/style.js";
 
 // JSX
-export { jsx, Fragment } from "./jsx";
-export type { JsxVNodeChild, JsxVNodeChildren, FunctionComponent } from "./jsx";
+export { jsx, Fragment } from "./jsx.js";
+export type {
+  JsxVNodeChild,
+  JsxVNodeChildren,
+  FunctionComponent
+} from "./jsx.js";

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,7 +1,7 @@
-import { Module } from "./modules/module";
-import { vnode, VNode } from "./vnode";
-import * as is from "./is";
-import { htmlDomApi, DOMAPI } from "./htmldomapi";
+import { Module } from "./modules/module.js";
+import { vnode, VNode } from "./vnode.js";
+import * as is from "./is.js";
+import { htmlDomApi, DOMAPI } from "./htmldomapi.js";
 
 type NonUndefined<T> = T extends undefined ? never : T;
 

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace, import/export */
-import { Key, vnode, VNode, VNodeData } from "./vnode";
-import { h, ArrayOrElement } from "./h";
-import { Props } from "./modules/props";
+import { Key, vnode, VNode, VNodeData } from "./vnode.js";
+import { h, ArrayOrElement } from "./h.js";
+import { Props } from "./modules/props.js";
 
 // for conditional rendering we support boolean child element e.g cond && <tag />
 export type JsxVNodeChild =

--- a/src/modules/attributes.ts
+++ b/src/modules/attributes.ts
@@ -1,5 +1,5 @@
-import { VNode, VNodeData } from "../vnode";
-import { Module } from "./module";
+import { VNode, VNodeData } from "../vnode.js";
+import { Module } from "./module.js";
 
 export type Attrs = Record<string, string | number | boolean>;
 

--- a/src/modules/class.ts
+++ b/src/modules/class.ts
@@ -1,5 +1,5 @@
-import { VNode, VNodeData } from "../vnode";
-import { Module } from "./module";
+import { VNode, VNodeData } from "../vnode.js";
+import { Module } from "./module.js";
 
 export type Classes = Record<string, boolean>;
 

--- a/src/modules/dataset.ts
+++ b/src/modules/dataset.ts
@@ -1,5 +1,5 @@
-import { VNode, VNodeData } from "../vnode";
-import { Module } from "./module";
+import { VNode, VNodeData } from "../vnode.js";
+import { Module } from "./module.js";
 
 export type Dataset = Record<string, string>;
 

--- a/src/modules/eventlisteners.ts
+++ b/src/modules/eventlisteners.ts
@@ -1,5 +1,5 @@
-import { VNode, VNodeData } from "../vnode";
-import { Module } from "./module";
+import { VNode, VNodeData } from "../vnode.js";
+import { Module } from "./module.js";
 
 type Listener<T> = (this: VNode, ev: T, vnode: VNode) => void;
 

--- a/src/modules/module.ts
+++ b/src/modules/module.ts
@@ -5,7 +5,7 @@ import {
   DestroyHook,
   RemoveHook,
   PostHook
-} from "../hooks";
+} from "../hooks.js";
 
 export type Module = Partial<{
   pre: PreHook;

--- a/src/modules/props.ts
+++ b/src/modules/props.ts
@@ -1,5 +1,5 @@
-import { VNode, VNodeData } from "../vnode";
-import { Module } from "./module";
+import { VNode, VNodeData } from "../vnode.js";
+import { Module } from "./module.js";
 
 export type Props = Record<string, any>;
 

--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -1,5 +1,5 @@
-import { VNode, VNodeData } from "../vnode";
-import { Module } from "./module";
+import { VNode, VNodeData } from "../vnode.js";
+import { Module } from "./module.js";
 
 export type ElementStyle = Partial<CSSStyleDeclaration>;
 

--- a/src/thunk.ts
+++ b/src/thunk.ts
@@ -1,5 +1,5 @@
-import { VNode, VNodeData } from "./vnode";
-import { h, addNS } from "./h";
+import { VNode, VNodeData } from "./vnode.js";
+import { h, addNS } from "./h.js";
 
 export interface ThunkData extends VNodeData {
   fn: () => VNode;

--- a/src/tovnode.ts
+++ b/src/tovnode.ts
@@ -1,6 +1,6 @@
-import { addNS } from "./h";
-import { vnode, VNode } from "./vnode";
-import { htmlDomApi, DOMAPI } from "./htmldomapi";
+import { addNS } from "./h.js";
+import { vnode, VNode } from "./vnode.js";
+import { htmlDomApi, DOMAPI } from "./htmldomapi.js";
 
 export function toVNode(node: Node, domApi?: DOMAPI): VNode {
   const api: DOMAPI = domApi !== undefined ? domApi : htmlDomApi;

--- a/src/vnode.ts
+++ b/src/vnode.ts
@@ -1,11 +1,11 @@
-import { Hooks } from "./hooks";
-import { AttachData } from "./helpers/attachto";
-import { VNodeStyle } from "./modules/style";
-import { On } from "./modules/eventlisteners";
-import { Attrs } from "./modules/attributes";
-import { Classes } from "./modules/class";
-import { Props } from "./modules/props";
-import { Dataset } from "./modules/dataset";
+import { Hooks } from "./hooks.js";
+import { AttachData } from "./helpers/attachto.js";
+import { VNodeStyle } from "./modules/style.js";
+import { On } from "./modules/eventlisteners.js";
+import { Attrs } from "./modules/attributes.js";
+import { Classes } from "./modules/class.js";
+import { Props } from "./modules/props.js";
+import { Dataset } from "./modules/dataset.js";
 
 export type Key = string | number | symbol;
 


### PR DESCRIPTION
Closes #1087, #1102 (perhaps also #1103?)

Added `.js` extensions to the import specifiers, which have been to done via `ts-add-js-extension`.
(Reminder: A valid ES module requires the file extension in the import specifier.)

This makes `build/jsx.js` a valid ES module file, as it now imports `./h.js` instead of `./h`.