### PR TITLE
Restore Typescript intellisense

### DIFF
--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -100,7 +100,7 @@ export function jsx(
 }
 
 // See https://www.typescriptlang.org/docs/handbook/jsx.html#type-checking
-export namespace jsx {
+namespace JSXTypes {
   export type Element = VNode;
 
   /*
@@ -140,5 +140,11 @@ export namespace jsx {
 
   export interface IntrinsicElements extends HtmlElements {
     [elemName: string]: VNodeData;
+  }
+}
+
+export namespace jsx {
+  export namespace JSX {
+    export interface IntrinsicElements extends JSXTypes.IntrinsicElements {}
   }
 }


### PR DESCRIPTION
Typescript intellisense appears to have been broken by #1052. For example:

```tsx
<div>Hello, world!</div>
```

The above code generates `ts(7026)`: `JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.` This is because as of #1052, `src/jsx.ts` no longer exports the `JSX` namespace within the parent `jsx` namespace, since the tsconfig option `isolatedModules` doesn't support the `import export` syntax that was used for this previously.

This pull request contains a workaround that avoids `import export`, but still allows the `JSX` namespace to be exported, so that `isolatedModules` can be set, but Typescript intellisense also works.