### PR TITLE
[POC] feat: adds jsx props module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export { attributesModule } from "./modules/attributes";
 export { classModule } from "./modules/class";
 export { datasetModule } from "./modules/dataset";
 export { eventListenersModule } from "./modules/eventlisteners";
+export { jsxPropsModule } from "./modules/jsxprops";
 export { propsModule } from "./modules/props";
 export { styleModule } from "./modules/style";
 export type { Attrs } from "./modules/attributes";

--- a/src/modules/jsxprops.ts
+++ b/src/modules/jsxprops.ts
@@ -15,6 +15,7 @@ const DATASET = "dataset";
 const ATTRS = "attrs";
 const PROPS = "props";
 const DATA = "data";
+const KEY = "key";
 const HYPHEN_CHAR = "-";
 const MODULE_PROPS: string[] = ["hook", "on", ATTRS, PROPS, DATASET];
 const DOM_PROPS: string[] = ["className", "tabIndex", "id"];
@@ -38,7 +39,7 @@ const forwardJsxProps = (oldVNode: VNode, _vnode: VNode): void => {
 
   const data: Record<string, any> = {},
     propKeys = [];
-  // preserve existing module values to be updated with
+  // preserve module values
   for (const key in vnode.data) {
     if (MODULE_PROPS.indexOf(key) > -1) {
       data[key] = vnode.data[key];
@@ -48,6 +49,8 @@ const forwardJsxProps = (oldVNode: VNode, _vnode: VNode): void => {
   }
   for (const propKey of propKeys) {
     const propValue = vnode.data[propKey];
+    // leave key unchanged
+    if (propKey === KEY) continue;
     const propertyIndex = DOM_PROPS.indexOf(propKey);
     if (propertyIndex > -1) {
       forwardProp(data, PROPS, DOM_PROPS[propertyIndex], propValue);

--- a/src/modules/jsxprops.ts
+++ b/src/modules/jsxprops.ts
@@ -1,0 +1,83 @@
+import { VNode, VNodeData } from "../vnode";
+import { Module } from "./module";
+
+const kebabToCamel = (value: string) =>
+  value
+    .split("-")
+    .map((word, i) =>
+      i > 0
+        ? word[0].toUpperCase() + word.slice(1).toLowerCase()
+        : word.toLowerCase()
+    )
+    .join("");
+
+const DATASET = "dataset";
+const ATTRS = "attrs";
+const PROPS = "props";
+const DATA = "data";
+const HYPHEN_CHAR = "-";
+const MODULE_PROPS: string[] = ["hook", "on", ATTRS, PROPS, DATASET];
+const DOM_PROPS: string[] = ["className", "tabIndex", "id"];
+
+const forwardProp = (
+  data: VNodeData,
+  moduleName: string,
+  key: string,
+  value: any
+): void => {
+  if (data[moduleName]) {
+    data[moduleName]![key] = value;
+  } else {
+    data[moduleName] = { [key]: value };
+  }
+};
+
+const forwardJsxProps = (oldVNode: VNode, _vnode: VNode): void => {
+  const vnode: VNode = _vnode || oldVNode;
+  if (!vnode.data) return;
+
+  const data: Record<string, any> = {},
+    propKeys = [];
+  // preserve existing module values to be updated with
+  for (const key in vnode.data) {
+    if (MODULE_PROPS.indexOf(key) > -1) {
+      data[key] = vnode.data[key];
+    } else {
+      propKeys.push(key);
+    }
+  }
+  for (const propKey of propKeys) {
+    const propValue = vnode.data[propKey];
+    const propertyIndex = DOM_PROPS.indexOf(propKey);
+    if (propertyIndex > -1) {
+      forwardProp(data, PROPS, DOM_PROPS[propertyIndex], propValue);
+      continue;
+    }
+    // check if prop instructs a module (using prefix)
+    const hyphenIdx = propKey.indexOf(HYPHEN_CHAR);
+    if (hyphenIdx > 0) {
+      const prefix = propKey.slice(0, hyphenIdx);
+      const instructedModule =
+        prefix === DATA
+          ? DATA
+          : MODULE_PROPS.find((moduleName) => moduleName === prefix);
+      if (instructedModule) {
+        const postfix: string = propKey.slice(hyphenIdx + 1);
+        if (instructedModule === DATA) {
+          forwardProp(data, DATASET, kebabToCamel(postfix), propValue);
+        } else {
+          forwardProp(data, instructedModule, postfix, propValue);
+        }
+        continue;
+      }
+    }
+    forwardProp(data, ATTRS, propKey, propValue);
+  }
+
+  vnode.data = data;
+};
+
+export const jsxPropsModule: Module = {
+  create: forwardJsxProps,
+  update: forwardJsxProps
+};

--- a/test/unit/jsxprops.tsx
+++ b/test/unit/jsxprops.tsx
@@ -1,0 +1,234 @@
+import { assert } from "@esm-bundle/chai";
+import { jsx, init, jsxPropsModule } from "../../src/index";
+
+const patch = init([jsxPropsModule], undefined, {
+  experimental: {
+    fragments: true
+  }
+});
+
+describe("snabbdom", () => {
+  describe("jsxprops", () => {
+    it("forwards props to attributes", () => {
+      const container = document.createElement("div");
+      const vnode = <div title="foo" aria-hidden="true" />;
+
+      patch(container, vnode);
+
+      assert.deepStrictEqual(vnode, {
+        sel: "div",
+        data: { attrs: { title: "foo", "aria-hidden": "true" } },
+        elm: undefined,
+        text: undefined,
+        key: undefined
+      });
+    });
+
+    ["className", "id", "tabIndex"].forEach((prop) => {
+      const values: Record<string, any> = {
+        className: ".foo",
+        id: "#foo",
+        tabIndex: 0
+      };
+
+      it(`forwards ${prop} to props`, () => {
+        const container = document.createElement("div");
+        const props = { [prop]: values[prop] };
+        const vnode = <div {...props} />;
+
+        patch(container, vnode);
+
+        assert.deepStrictEqual(vnode, {
+          sel: "div",
+          data: { props },
+          elm: undefined,
+          text: undefined,
+          key: undefined
+        });
+      });
+    });
+
+    it("forwards declared hooks", () => {
+      let created = false;
+      const handleInsert = () => {
+        created = true;
+      };
+
+      const container = document.createElement("div");
+      const vnode = <div hook-insert={handleInsert} />;
+
+      patch(container, vnode);
+
+      assert.isTrue(created);
+    });
+
+    it("forwards declared event listeners", () => {
+      let clicked = false;
+      const onClick = () => {
+        clicked = true;
+      };
+
+      const container = document.createElement("div");
+      const vnode = <div on-click={onClick} />;
+
+      patch(container, vnode);
+      container.click();
+
+      assert.isTrue(clicked);
+    });
+
+    it("forwards declared attributes", () => {
+      const container = document.createElement("div");
+      const vnode = <input attrs-tabindex={0} />;
+
+      patch(container, vnode);
+
+      assert.deepStrictEqual(vnode, {
+        sel: "div",
+        data: { attrs: { tabindex: 0 } },
+        elm: undefined,
+        text: undefined,
+        key: undefined
+      });
+    });
+
+    it("forwards declared props", () => {
+      const container = document.createElement("div");
+      const vnode = <input props-ariaLabel="foo" />;
+
+      patch(container, vnode);
+
+      assert.deepStrictEqual(vnode, {
+        sel: "div",
+        data: { props: { ariaLabel: "foo" } },
+        elm: undefined,
+        text: undefined,
+        key: undefined
+      });
+    });
+
+    it("forwards declared datasets", () => {
+      const container = document.createElement("div");
+      const vnode = <input data-foo-bar="baz" />;
+
+      patch(container, vnode);
+
+      assert.deepStrictEqual(vnode, {
+        sel: "div",
+        data: { dataset: { fooBar: "baz" } },
+        elm: undefined,
+        text: undefined,
+        key: undefined
+      });
+    });
+
+    it("doesn't forward 'key' prop", () => {
+      const container = document.createElement("div");
+      const vnode = <input key="key" />;
+
+      patch(container, vnode);
+
+      assert.deepStrictEqual(vnode, {
+        sel: "div",
+        data: { key: "key" },
+        elm: undefined,
+        text: undefined,
+        key: undefined
+      });
+    });
+
+    describe("module compatibility", () => {
+      it("preserves 'hook' prop value", () => {
+        let created = false,
+          pre = false;
+        const handlePre = () => {
+          pre = true;
+        };
+        const handleCreate = () => {
+          created = false;
+        };
+
+        const container = document.createElement("div");
+        const vnode = (
+          <div hook-insert={handlePre} hook={{ create: handleCreate }} />
+        );
+
+        patch(container, vnode);
+
+        assert.isTrue(created);
+        assert.isTrue(pre);
+      });
+
+      it("preserves 'on' prop value", () => {
+        let clicked = false,
+          hovered = false;
+        const handleMouseEnter = () => {
+          hovered = true;
+        };
+        const handleClick = () => {
+          clicked = false;
+        };
+
+        const container = document.createElement("div");
+        const vnode = (
+          <div on-mouseEnter={handleMouseEnter} on={{ click: handleClick }} />
+        );
+
+        patch(container, vnode);
+
+        container.click();
+        container.dispatchEvent(new MouseEvent("mouseenter"));
+
+        assert.isTrue(clicked);
+        assert.isTrue(hovered);
+      });
+
+      it("preserves 'attrs' prop value", () => {
+        const container = document.createElement("div");
+        const vnode = <input attrs-tabindex={0} attrs={{ value: "bar" }} />;
+
+        patch(container, vnode);
+
+        assert.deepStrictEqual(vnode, {
+          sel: "div",
+          data: { attrs: { tabindex: 0, value: "bar" } },
+          elm: undefined,
+          text: undefined,
+          key: undefined
+        });
+      });
+
+      it("preserves 'props' prop value", () => {
+        const container = document.createElement("div");
+        const vnode = <input props-tabIndex={0} props={{ value: "bar" }} />;
+
+        patch(container, vnode);
+
+        assert.deepStrictEqual(vnode, {
+          sel: "div",
+          data: { props: { tabIndex: 0, value: "bar" } },
+          elm: undefined,
+          text: undefined,
+          key: undefined
+        });
+      });
+
+      it("preserves 'dataset' prop value", () => {
+        const container = document.createElement("div");
+        const vnode = (
+          <input data-some-value="foo" dataset={{ anotherValue: "bar" }} />
+        );
+
+        patch(container, vnode);
+
+        assert.deepStrictEqual(vnode, {
+          sel: "div",
+          data: { dataset: { someValue: "foo", anotherValue: "bar" } },
+          elm: undefined,
+          text: undefined,
+          key: undefined
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
_NOTE: This PR is a POC to illustrate how Snabbdom could enable cleaner JSX prop handling per #1112, but as a non-breaking change that retains the package's existing architecture. It's also based on my [own plugin](https://github.com/geotrev/snabbdom-transform-jsx-props), but pared down as a better starting point._

### Todo

- [ ] Evaluate automatic DOM property vs attribute handling (similar to React and others)
- [ ] Update READMEs
- [ ] Type interfaces

## Descriptions

Adds `jsxPropsModule` to enable cleaner Snabbdom JSX prop signatures.

In short, the module forwards JSX props to their appropriate module (`props`, `dataset`, `eventlisteners`, etc). As a fallback, any unhandled props are treated as attributes.

This isn't behind an `options.experimental` flag since using the module feels like enough of an opt-in already, but open to suggestions if certain functionality should be instated to prevent foot-🔫s.

## Details

Use the module with `init` to create virtual nodes.

```
const patch = init(
  [
    jsxPropsModule,
    classModule,
    eventListenersModule
  ],
  htmlDomApi
)
```

Example of JSX using this module:

```
<div className="my-component" hook-insert={() => {}}>
  <h1 data-foo-heading={true}>Hello world</h1>
  <svg aria-hidden="true" />
  <a href="#" attrs-style="color: blue" tabIndex="0" on-click={() => {}}>Link</a>
</div>
```

View the unit test file for more samples. :) Any additional concerns, such as other modules/features to handle but aren't included in this POC, can be noted for a full and proper update should this module make sense for the package.

Requirements:

- `@babel/plugin-transform-react-jsx`, per README
- Must be added as the first module so the next modules (`eventlisteners`, `class`, `style`, etc) can detect these props.

The module handles these specific cases / features (open to suggestions/changes if appropriate):

- **Module instruction:** Providing a prefix instructs the module to add the suffix of the prop to the appropriate module. Some modules (like `class`) are omitted as they serve no functional purpose given the existence of a pre-existing, ergonomic option (in this case, `className`).

  | prefix    | module/feature  | prefix example       | result                                   |
  | --------- | --------------- | -------------------- | ---------------------------------------- |
  | `hook-*`  | hooks           | `hook-insert={fn}`   | `{ data: { hooks: { insert: fn }}}`      |
  | `on-*`    | event listeners | `on-mouseDown={fn}`  | `{ data: { on: { mouseDown: fn }}}`      |
  | `attrs-*` | attributes      | `attrs-value="foo"`  | `{ data: { attrs: { value: "foo" }}}`    |
  | `props-*` | props           | `props-value="foo"`  | `{ data: { props: { value: "foo" }}}`    |
  | `data-*`  | dataset         | `data-foo-bar="baz"` | `{ data: { dataset: { fooBar: "baz" }}}` |

  Hyphens are used for simplicity of the prop check. If a hyphen doesn't exist on the prop, then no module forwarding needs to happen. Open to ideas if React-style camelCase is better here.

- **Smarter prop handling:** Always moves a predefined set of JSX props into the `props` module (e.g., `className`). See `PROPERTY_PROPS` in `modules/jsxprops.ts` for the initial list (many others could be added).

  Examples:

  ```
  <div tabIndex={0} /> // { data: { props: { tabIndex: 0 }}}
  ```

- **Defaults to attributes:** Forwards all other props to the attributes module.
- **Non-breaking:** Does not conflict with the existing form of Snabbdom JSX props (e.g., `attrs={{...}}`), and shouldn't cause regressions for consumers mixing prop signatures, while preferring the flattened style introduced by this module.
