### PR TITLE
fix: tweak `VNodeStyle` to improve performance of type checking

### DIFF
--- a/src/modules/style.ts
+++ b/src/modules/style.ts
@@ -1,13 +1,17 @@
 import { VNode, VNodeData } from "../vnode";
 import { Module } from "./module";
 
-export type ElementStyle = Partial<CSSStyleDeclaration>;
+type ElementStyle = { [K in keyof CSSStyleDeclaration]?: string };
 
-export type VNodeStyle = ElementStyle &
-  Record<string, string> & {
-    delayed?: ElementStyle & Record<string, string>;
-    remove?: ElementStyle & Record<string, string>;
-  };
+interface InnerStyle extends ElementStyle {
+  [K: string]: string | undefined;
+}
+
+export interface VNodeStyle extends ElementStyle {
+  delayed?: InnerStyle;
+  remove?: InnerStyle;
+  [K: string]: InnerStyle | string | undefined;
+}
 
 // Binding `requestAnimationFrame` like this fixes a bug in IE/Edge. See #360 and #409.
 const raf =


### PR DESCRIPTION
This should _somewhat_ improve the regression described in #1114.

Timing the build of [this example](https://github.com/schlawg/snabbdom-tsc-mre) with `tsc --extendedDiagnostics --noEmit` changes the build time from currently at around 5.4 seconds to 3.02 seconds (on my machine). The 3.5.1 release takes around 1.30 seconds. So build times are still slower, but I don't think we can make it any better if we want the precise type for `style` that reflects the actual CSS properties.

If this is fast enough we should merge this PR. If it is still not acceptable then we should revert the change to the `style` property to the less precise type.