### PR TITLE
Simplify JSX types

### DIFF
--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -103,37 +103,15 @@ export function jsx(
 namespace JSXTypes {
   export type Element = VNode;
 
-  /*
-  IfEquals/WritableKeys: https://stackoverflow.com/questions/52443276/how-to-exclude-getter-only-properties-from-type-in-typescript/52473108#52473108
-  */
-  export type IfEquals<X, Y, Output> =
-    (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
-      ? Output
-      : never;
-
-  export type WritableKeys<T> = {
-    [P in keyof T]-?: IfEquals<
-      { [Q in P]: T[P] },
-      { -readonly [Q in P]: T[P] },
-      P
-    >;
-  }[keyof T];
-
   export type ElementProperties<T> = {
-    [Property in WritableKeys<T> as T[Property] extends
-      | string
-      | number
-      | null
-      | undefined
-      ? Property
-      : never]?: T[Property];
+    [P in keyof T as T[P] extends string | number | null | undefined
+      ? P
+      : never]?: T[P];
   };
-
-  export type VNodeProps<T> = ElementProperties<T> & Props;
 
   export type HtmlElements = {
     [Property in keyof HTMLElementTagNameMap]: VNodeData<
-      VNodeProps<HTMLElementTagNameMap[Property]>
+      ElementProperties<HTMLElementTagNameMap[Property]> & Props
     >;
   };
 


### PR DESCRIPTION
A quick go at simplifying the JSX types, potentially improving the type checking performance issue reported in https://github.com/snabbdom/snabbdom/issues/1114.

Currently `ElementProperties<T>` filters out non-writable keys from the properties of `HTMLElementTagNameMap` (i.e., properties that are merely getters). This PR removes that filtering. Since the whole thing is `&`'ed with `Props` (which is `Record<string, any>`) anyway this does not affect what types are valid in JSX. It only affects the auto-completions made available in IDE, as they will now also include properties that are not writable. If this causes an improvement to type-checking, then that seems like a worthwhile tradeoff.